### PR TITLE
fix rtree index scan when filter is completely pruned out

### DIFF
--- a/src/spatial/index/rtree/rtree_index_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_scan.cpp
@@ -26,7 +26,12 @@ BindInfo RTreeIndexScanBindInfo(const optional_ptr<FunctionData> bind_data_p) {
 //-------------------------------------------------------------------------
 // Global State
 //-------------------------------------------------------------------------
-struct RTreeIndexScanGlobalState : public GlobalTableFunctionState {
+struct RTreeIndexScanGlobalState final : public GlobalTableFunctionState {
+	//! The DataChunk containing all read columns.
+	//! This includes filter columns, which are immediately removed.
+	DataChunk all_columns;
+	vector<idx_t> projection_ids;
+
 	ColumnFetchState fetch_state;
 	TableScanState local_storage_state;
 	vector<StorageIndex> column_ids;
@@ -39,7 +44,6 @@ struct RTreeIndexScanGlobalState : public GlobalTableFunctionState {
 static unique_ptr<GlobalTableFunctionState> RTreeIndexScanInitGlobal(ClientContext &context,
                                                                      TableFunctionInitInput &input) {
 	auto &bind_data = input.bind_data->Cast<RTreeIndexScanBindData>();
-
 	auto result = make_uniq<RTreeIndexScanGlobalState>();
 
 	// Setup the scan state for the local storage
@@ -62,6 +66,26 @@ static unique_ptr<GlobalTableFunctionState> RTreeIndexScanInitGlobal(ClientConte
 	// Initialize the scan state for the index
 	result->index_state = bind_data.index.Cast<RTreeIndex>().InitializeScan(bind_data.bbox);
 
+	// Early out if there is nothing to project
+	if (!input.CanRemoveFilterColumns()) {
+		return std::move(result);
+	}
+
+	// We need this to project out what we scan from the underlying table.
+	result->projection_ids = input.projection_ids;
+
+	auto &duck_table = bind_data.table.Cast<DuckTableEntry>();
+	const auto &columns = duck_table.GetColumns();
+	vector<LogicalType> scanned_types;
+	for (const auto &col_idx : input.column_indexes) {
+		if (col_idx.IsRowIdColumn()) {
+			scanned_types.emplace_back(LogicalType::ROW_TYPE);
+		} else {
+			scanned_types.push_back(columns.GetColumn(col_idx.ToLogical()).Type());
+		}
+	}
+	result->all_columns.Initialize(context, scanned_types);
+
 	return std::move(result);
 }
 
@@ -83,8 +107,17 @@ static void RTreeIndexScanExecute(ClientContext &context, TableFunctionInput &da
 	}
 
 	// Fetch the data from the local storage given the row ids
-	bind_data.table.GetStorage().Fetch(transaction, output, state.column_ids, state.row_ids, row_count,
+	if (state.projection_ids.empty()) {
+		bind_data.table.GetStorage().Fetch(transaction, output, state.column_ids, state.row_ids, row_count,
+		                                   state.fetch_state);
+		return;
+	}
+
+	// Otherwise, we need to first fetch into our scan chunk, and then project out the result
+	state.all_columns.Reset();
+	bind_data.table.GetStorage().Fetch(transaction, state.all_columns, state.column_ids, state.row_ids, row_count,
 	                                   state.fetch_state);
+	output.ReferenceColumns(state.all_columns, state.projection_ids);
 }
 
 //-------------------------------------------------------------------------

--- a/test/sql/index/rtree_filter_prune.test
+++ b/test/sql/index/rtree_filter_prune.test
@@ -1,0 +1,20 @@
+require spatial
+
+statement ok
+set disabled_optimizers="column_lifetime";
+
+statement ok
+CREATE TABLE t1 AS
+SELECT st_point(i, j) as pt, row_number() over () as i, row_number () over () as j
+FROM range(0, 3) as r(i), range(0, 3) as rr(j);
+
+statement ok
+CREATE INDEX my_idx ON t1 USING RTREE (pt);
+
+query I rowsort
+SELECT j FROM t1 WHERE (i >= -100 AND i <= 100) AND ST_Contains(ST_GeomFromText('POLYGON((0 0, 0 50, 50 50, 50 0, 0 0))'), pt);
+----
+5
+6
+8
+9


### PR DESCRIPTION
If the optimizer checks the statistics and realizes that a column is only used in a filter which is always going to be true (due to the table stats), it pushes down a projection and expects the underlying scan node to not fetch the column. The R-Tree index scan didn't respect this, which could lead to mismatch between the number of columns scanned and the number of columns expected.

Now, if there are projection ids pushed down, we first scan into a separate data chunk containing all table columns, before projecting out the selected columns to the output chunk. 

Closes #499