### PR TITLE
Fix ST_DWithin_Spheroid function registration to match implementation

### DIFF
--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -1061,7 +1061,8 @@ struct ST_DWithin_Spheroid {
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
 				variant.AddParameter("p1", GeoTypes::POINT_2D());
 				variant.AddParameter("p2", GeoTypes::POINT_2D());
-				variant.SetReturnType(LogicalType::DOUBLE);
+				variant.AddParameter("distance", LogicalType::DOUBLE);
+				variant.SetReturnType(LogicalType::BOOLEAN);
 
 				variant.SetFunction(Execute);
 			});


### PR DESCRIPTION
**Description**
This PR fixes a mismatch in the registration of the ST_DWithin_Spheroid function (#520). The function implementation expects three parameters (two points and a distance limit) and returns a boolean value, but the registration was incorrectly configured with only two parameters and a DOUBLE return type.

**Changes**
Added the missing 'distance' parameter of type DOUBLE to the function registration
Changed the return type from DOUBLE to BOOLEAN to correctly match the function implementation
The function now properly checks if two points are within a specified distance using an ellipsoidal model