### PR TITLE
Implement `ST_Centroid` in SGL

### DIFF
--- a/.github/workflows/StableDistributionPipeline.yml
+++ b/.github/workflows/StableDistributionPipeline.yml
@@ -42,5 +42,5 @@ jobs:
       duckdb_version: v1.2.2
       ci_tools_version: v1.2.1
       extension_name: spatial
-      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/v1.2.1' }}
+      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/v1.2.2' }}
       exclude_archs: linux_amd64_musl

--- a/src/sgl/sgl.cpp
+++ b/src/sgl/sgl.cpp
@@ -1239,28 +1239,30 @@ size_t to_wkb_size(const geometry *geom) {
 size_t to_wkb(const geometry *geom, uint8_t *buffer, size_t size) {
 
 #define WKB_WRITE_U8(PTR, VAL)                                                                                         \
-do {                                                                                                               \
-uint8_t v = VAL;                                                                                               \
-memcpy(PTR, &v, sizeof(uint8_t));                                                                              \
-PTR += sizeof(uint8_t);                                                                                        \
-} while (0)
+	do {                                                                                                               \
+		uint8_t v = VAL;                                                                                               \
+		memcpy(PTR, &v, sizeof(uint8_t));                                                                              \
+		PTR += sizeof(uint8_t);                                                                                        \
+	} while (0)
 #define WKB_WRITE_U32(PTR, VAL)                                                                                        \
-do {                                                                                                               \
-uint32_t v = VAL;                                                                                              \
-memcpy(PTR, &v, sizeof(uint32_t));                                                                             \
-PTR += sizeof(uint32_t);                                                                                       \
-} while (0)
+	do {                                                                                                               \
+		uint32_t v = VAL;                                                                                              \
+		memcpy(PTR, &v, sizeof(uint32_t));                                                                             \
+		PTR += sizeof(uint32_t);                                                                                       \
+	} while (0)
+
 #define WKB_WRITE_DOUBLE(PTR, VAL)                                                                                     \
-do {                                                                                                               \
-double v = VAL;                                                                                                \
-memcpy(PTR, &v, sizeof(double));                                                                               \
-PTR += sizeof(double);                                                                                         \
-} while (0)
+	do {                                                                                                               \
+		double v = VAL;                                                                                                \
+		memcpy(PTR, &v, sizeof(double));                                                                               \
+		PTR += sizeof(double);                                                                                         \
+	} while (0)
+
 #define WKB_WRITE_DATA(PTR, SRC, SIZE)                                                                                 \
-do {                                                                                                               \
-memcpy(PTR, SRC, SIZE);                                                                                        \
-PTR += SIZE;                                                                                                   \
-} while (0)
+	do {                                                                                                               \
+		memcpy(PTR, SRC, SIZE);                                                                                        \
+		PTR += SIZE;                                                                                                   \
+	} while (0)
 
 	auto ptr = buffer;
 

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -383,34 +383,6 @@ struct ST_BuildArea {
 	}
 };
 
-struct ST_Centroid {
-	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
-		const auto &lstate = LocalState::ResetAndGet(state);
-
-		UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](const string_t &geom_blob) {
-			const auto geom = lstate.Deserialize(geom_blob);
-			const auto centroid = geom.get_centroid();
-			return lstate.Serialize(result, centroid);
-		});
-	}
-
-	static void Register(DatabaseInstance &db) {
-		FunctionBuilder::RegisterScalar(db, "ST_Centroid_GEOS", [](ScalarFunctionBuilder &func) {
-			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
-				variant.AddParameter("geom", GeoTypes::GEOMETRY());
-				variant.SetReturnType(GeoTypes::GEOMETRY());
-
-				variant.SetInit(LocalState::Init);
-				variant.SetFunction(Execute);
-			});
-
-			func.SetDescription("Returns the centroid of a geometry");
-			func.SetTag("ext", "spatial");
-			func.SetTag("category", "construction");
-		});
-	}
-};
-
 struct ST_Contains : AsymmetricPreparedBinaryFunction<ST_Contains> {
 	static bool ExecutePredicateNormal(const GeosGeometry &lhs, const GeosGeometry &rhs) {
 		return lhs.contains(rhs);
@@ -2496,7 +2468,6 @@ void RegisterGEOSModule(DatabaseInstance &db) {
 	ST_Boundary::Register(db);
 	ST_Buffer::Register(db);
 	ST_BuildArea::Register(db);
-	ST_Centroid::Register(db);
 	ST_Contains::Register(db);
 	ST_ContainsProperly::Register(db);
 	ST_ConcaveHull::Register(db);

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -1296,9 +1296,10 @@ struct ST_Centroid {
 
 			sgl::vertex_xyzm centroid = {0, 0, 0, 0};
 			if (!sgl::ops::get_centroid(&geom, &centroid)) {
-				// Couldnt get the centroid, return an empty geometrycollection.
+				// Couldnt get the centroid, return an empty point.
+				// NOTE: This is the PostGIS behavior, the docs are wrong.
 				sgl::geometry empty;
-				sgl::multi_geometry::init_empty(&empty, geom.has_z(), geom.has_m());
+				sgl::point::init_empty(&empty, geom.has_z(), geom.has_m());
 				return lstate.Serialize(result, empty);
 			}
 


### PR DESCRIPTION
Computing the centroid over `1500951` overture building footprints now takes about `0.044s`, compared  to `0.368` using the previous GEOS implementation (mostly due to serialization/allocation overhead)