### PR TITLE
Duplicate symbols when statically linking avro and spatial

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -107,7 +107,7 @@ ExternalProject_Add(
     DEPENDS ${GDAL_DEPENDENCIES}
     URL ${CMAKE_CURRENT_SOURCE_DIR}/vendor/gdal385.zip
     CONFIGURE_HANDLED_BY_BUILD TRUE
-    PATCH_COMMAND patch -p1 -i "${CMAKE_CURRENT_LIST_DIR}/patches/remove_filehandler${PATCH_NAME_ENDING}.patch" && patch -p1 -i "${CMAKE_CURRENT_LIST_DIR}/patches/msyspatch${PATCH_NAME_ENDING}.patch"
+    PATCH_COMMAND patch -p1 -i "${CMAKE_CURRENT_LIST_DIR}/patches/remove_filehandler${PATCH_NAME_ENDING}.patch" && patch -p1 -i "${CMAKE_CURRENT_LIST_DIR}/patches/msyspatch${PATCH_NAME_ENDING}.patch" && patch -p1 -i "${CMAKE_CURRENT_LIST_DIR}/patches/gdal.patch"
     CMAKE_ARGS
     # CMake options
     -DCMAKE_CXX_COMPILER='${CMAKE_CXX_COMPILER}'
@@ -133,7 +133,7 @@ ExternalProject_Add(
     # Build static library
     -DBUILD_SHARED_LIBS=OFF
     ${CMAKE_GDAL_FLAGS}
-    
+
     # Arrow
     -DGDAL_USE_ARROW=OFF
     -DARROW_USE_STATIC_LIBRARIES=OFF
@@ -150,7 +150,7 @@ ExternalProject_Add(
     -DGDAL_USE_OPENSSL=${SPATIAL_USE_NETWORK}
     -DOPENSSL_USE_STATIC_LIBS=ON # Propagate to FindOpenSSL.cmake
     -DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}
-    
+
     # This is not true, but a bug in gdal's cmake files
     -DACCEPT_MISSING_SQLITE3_RTREE:BOOL=ON
     -DACCEPT_MISSING_SQLITE3_MUTEX_ALLOC:BOOL=ON

--- a/deps/patches/gdal.patch
+++ b/deps/patches/gdal.patch
@@ -1,0 +1,283 @@
+diff --git a/frmts/eeda/eedadataset.cpp b/frmts/eeda/eedadataset.cpp
+index 5f9f204..b995b8f 100644
+--- a/frmts/eeda/eedadataset.cpp
++++ b/frmts/eeda/eedadataset.cpp
+@@ -617,7 +617,7 @@ OGRFeature *GDALEEDALayer::GetNextRawFeature()
+                     if (poOtherProperties == nullptr)
+                         poOtherProperties = json_object_new_object();
+                     json_object_object_add(poOtherProperties, it.key, it.val);
+-                    json_object_get(it.val);
++                    gdal__json_object_get(it.val);
+                 }
+             }
+         }
+diff --git a/ogr/ogrsf_frmts/geojson/libjson/json_object.c b/ogr/ogrsf_frmts/geojson/libjson/json_object.c
+index 7a23c37..d42a134 100644
+--- a/ogr/ogrsf_frmts/geojson/libjson/json_object.c
++++ b/ogr/ogrsf_frmts/geojson/libjson/json_object.c
+@@ -285,7 +285,7 @@ static int json_escape_str(struct printbuf *pb, const char *str, size_t len, int
+
+ /* reference counting */
+
+-struct json_object *json_object_get(struct json_object *jso)
++struct json_object *gdal__json_object_get(struct json_object *jso)
+ {
+ 	if (!jso)
+ 		return jso;
+diff --git a/ogr/ogrsf_frmts/geojson/libjson/json_object.h b/ogr/ogrsf_frmts/geojson/libjson/json_object.h
+index 05f25b0..085faca 100644
+--- a/ogr/ogrsf_frmts/geojson/libjson/json_object.h
++++ b/ogr/ogrsf_frmts/geojson/libjson/json_object.h
+@@ -140,7 +140,7 @@ extern "C" {
+  * @see json_object_object_get()
+  * @see json_object_array_get_idx()
+  */
+-JSON_EXPORT struct json_object *json_object_get(struct json_object *obj);
++JSON_EXPORT struct json_object *gdal__json_object_get(struct json_object *obj);
+
+ /**
+  * Decrement the reference count of json_object and free if it reaches zero.
+@@ -152,14 +152,14 @@ JSON_EXPORT struct json_object *json_object_get(struct json_object *obj);
+  *
+  * Just like after calling `free()` on a block of memory, you must not use
+  * `obj` after calling `json_object_put()` on it or any object that it
+- * is a member of (unless you know you've called `json_object_get(obj)` to
++ * is a member of (unless you know you've called `gdal__json_object_get(obj)` to
+  * explicitly increment the refcount).
+  *
+  * NULL may be passed, which which case this is a no-op.
+  *
+  * @param obj the json_object instance
+  * @returns 1 if the object was freed.
+- * @see json_object_get()
++ * @see gdal__json_object_get()
+  */
+ JSON_EXPORT int json_object_put(struct json_object *obj);
+
+@@ -365,7 +365,7 @@ JSON_C_CONST_FUNCTION(JSON_EXPORT size_t json_c_object_sizeof(void));
+  *
+  * If you want to retain a reference to the added object, independent
+  * of the lifetime of obj, you must increment the refcount with
+- * `json_object_get(val)` (and later release it with json_object_put()).
++ * `gdal__json_object_get(val)` (and later release it with json_object_put()).
+  *
+  * Since ownership transfers to `obj`, you must make sure
+  * that you do in fact have ownership over `val`.  For instance,
+diff --git a/ogr/ogrsf_frmts/geojson/libjson/json_object_iterator.h b/ogr/ogrsf_frmts/geojson/libjson/json_object_iterator.h
+index a9b1433..1f79063 100644
+--- a/ogr/ogrsf_frmts/geojson/libjson/json_object_iterator.h
++++ b/ogr/ogrsf_frmts/geojson/libjson/json_object_iterator.h
+@@ -184,7 +184,7 @@ JSON_EXPORT const char *json_object_iter_peek_name(const struct json_object_iter
+  *         instance of the referenced name/value pair;  the
+  *         value's reference count is not changed by this
+  *         function: if you plan to hold on to this json-c node,
+- *         take a look at json_object_get() and
++ *         take a look at gdal__json_object_get() and
+  *         json_object_put(). IMPORTANT: json-c API represents
+  *         the JSON Null value as a NULL json_object instance
+  *         pointer.
+diff --git a/ogr/ogrsf_frmts/geojson/libjson/json_tokener.c b/ogr/ogrsf_frmts/geojson/libjson/json_tokener.c
+index 1d24104..44fa630 100644
+--- a/ogr/ogrsf_frmts/geojson/libjson/json_tokener.c
++++ b/ogr/ogrsf_frmts/geojson/libjson/json_tokener.c
+@@ -408,7 +408,7 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
+ 		case json_tokener_state_finish:
+ 			if (tok->depth == 0)
+ 				goto out;
+-			obj = json_object_get(current);
++			obj = gdal__json_object_get(current);
+ 			json_tokener_reset_level(tok, tok->depth);
+ 			tok->depth--;
+ 			goto redo_char;
+@@ -1209,7 +1209,7 @@ out:
+
+ 	if (tok->err == json_tokener_success)
+ 	{
+-		json_object *ret = json_object_get(current);
++		json_object *ret = gdal__json_object_get(current);
+ 		int ii;
+
+ 		/* Partially reset, so we parse additional objects on subsequent calls. */
+diff --git a/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp b/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
+index 274236e..19f9fdb 100644
+--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
++++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
+@@ -153,7 +153,7 @@ static void OGRGeoJSONPatchPosition(json_object *poJSonCoordinates,
+     {
+         json_object_array_add(
+             poJSonCoordinates,
+-            json_object_get(json_object_array_get_idx(poNativeCoordinates, i)));
++            gdal__json_object_get(json_object_array_get_idx(poNativeCoordinates, i)));
+     }
+ }
+
+@@ -438,7 +438,7 @@ static void OGRGeoJSONPatchGeometry(json_object *poJSonGeometry,
+             continue;
+         }
+
+-        json_object_object_add(poJSonGeometry, it.key, json_object_get(it.val));
++        json_object_object_add(poJSonGeometry, it.key, gdal__json_object_get(it.val));
+     }
+ }
+
+@@ -617,7 +617,7 @@ json_object *OGRGeoJSONWriteFeature(OGRFeature *poFeature,
+                 }
+                 if (strcmp(it.key, "geometry") == 0)
+                 {
+-                    poNativeGeom = json_object_get(it.val);
++                    poNativeGeom = gdal__json_object_get(it.val);
+                     continue;
+                 }
+                 if (strcmp(it.key, "id") == 0)
+@@ -696,7 +696,7 @@ json_object *OGRGeoJSONWriteFeature(OGRFeature *poFeature,
+                     continue;
+                 }
+
+-                json_object_object_add(poObj, it.key, json_object_get(it.val));
++                json_object_object_add(poObj, it.key, gdal__json_object_get(it.val));
+             }
+             json_object_put(poNativeJSon);
+         }
+@@ -965,7 +965,7 @@ json_object *OGRGeoJSONWriteAttributes(OGRFeature *poFeature,
+                         const char *pszProp{json_object_get_string(poProperty)};
+                         if (pszProp && strcmp(pszProp, pszStr) == 0)
+                         {
+-                            poObjProp = json_object_get(poProperty);
++                            poObjProp = gdal__json_object_get(poProperty);
+                         }
+                     }
+                 }
+diff --git a/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1layer.cpp b/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1layer.cpp
+index e2a5e2b..2dcc1dd 100644
+--- a/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1layer.cpp
++++ b/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1layer.cpp
+@@ -399,7 +399,7 @@ bool OGRPLScenesDataV1Layer::GetNextPage()
+             }
+             if (m_poAttributeFilter != nullptr)
+             {
+-                json_object_get(m_poAttributeFilter);
++                gdal__json_object_get(m_poAttributeFilter);
+                 json_object_array_add(poConfig, m_poAttributeFilter);
+             }
+
+@@ -1278,7 +1278,7 @@ GIntBig OGRPLScenesDataV1Layer::GetFeatureCount(int bForce)
+         }
+         if (m_poAttributeFilter != nullptr)
+         {
+-            json_object_get(m_poAttributeFilter);
++            gdal__json_object_get(m_poAttributeFilter);
+             json_object_array_add(poConfig, m_poAttributeFilter);
+         }
+
+diff --git a/port/cpl_json.cpp b/port/cpl_json.cpp
+index 99b2c7a..5b1778c 100644
+--- a/port/cpl_json.cpp
++++ b/port/cpl_json.cpp
+@@ -82,7 +82,7 @@ CPLJSONDocument::~CPLJSONDocument()
+ }
+
+ CPLJSONDocument::CPLJSONDocument(const CPLJSONDocument &other)
+-    : m_poRootJsonObject(json_object_get(TO_JSONOBJ(other.m_poRootJsonObject)))
++    : m_poRootJsonObject(gdal__json_object_get(TO_JSONOBJ(other.m_poRootJsonObject)))
+ {
+ }
+
+@@ -93,7 +93,7 @@ CPLJSONDocument &CPLJSONDocument::operator=(const CPLJSONDocument &other)
+
+     if (m_poRootJsonObject)
+         json_object_put(TO_JSONOBJ(m_poRootJsonObject));
+-    m_poRootJsonObject = json_object_get(TO_JSONOBJ(other.m_poRootJsonObject));
++    m_poRootJsonObject = gdal__json_object_get(TO_JSONOBJ(other.m_poRootJsonObject));
+
+     return *this;
+ }
+@@ -202,7 +202,7 @@ void CPLJSONDocument::SetRoot(const CPLJSONObject &oRoot)
+ {
+     if (m_poRootJsonObject)
+         json_object_put(TO_JSONOBJ(m_poRootJsonObject));
+-    m_poRootJsonObject = json_object_get(TO_JSONOBJ(oRoot.m_poJsonObject));
++    m_poRootJsonObject = gdal__json_object_get(TO_JSONOBJ(oRoot.m_poJsonObject));
+ }
+
+ /**
+@@ -524,7 +524,7 @@ CPLJSONObject::CPLJSONObject(double dfVal)
+
+ CPLJSONObject::CPLJSONObject(const std::string &osName,
+                              const CPLJSONObject &oParent)
+-    : m_poJsonObject(json_object_get(json_object_new_object())), m_osKey(osName)
++    : m_poJsonObject(gdal__json_object_get(json_object_new_object())), m_osKey(osName)
+ {
+     json_object_object_add(TO_JSONOBJ(oParent.m_poJsonObject), osName.c_str(),
+                            TO_JSONOBJ(m_poJsonObject));
+@@ -532,7 +532,7 @@ CPLJSONObject::CPLJSONObject(const std::string &osName,
+
+ CPLJSONObject::CPLJSONObject(const std::string &osName,
+                              JSONObjectH poJsonObject)
+-    : m_poJsonObject(json_object_get(TO_JSONOBJ(poJsonObject))), m_osKey(osName)
++    : m_poJsonObject(gdal__json_object_get(TO_JSONOBJ(poJsonObject))), m_osKey(osName)
+ {
+ }
+
+@@ -561,7 +561,7 @@ CPLJSONObject::~CPLJSONObject()
+ }
+
+ CPLJSONObject::CPLJSONObject(const CPLJSONObject &other)
+-    : m_poJsonObject(json_object_get(TO_JSONOBJ(other.m_poJsonObject))),
++    : m_poJsonObject(gdal__json_object_get(TO_JSONOBJ(other.m_poJsonObject))),
+       m_osKey(other.m_osKey)
+ {
+ }
+@@ -580,7 +580,7 @@ CPLJSONObject &CPLJSONObject::operator=(const CPLJSONObject &other)
+     m_osKey = other.m_osKey;
+     if (m_poJsonObject)
+         json_object_put(TO_JSONOBJ(m_poJsonObject));
+-    m_poJsonObject = json_object_get(TO_JSONOBJ(other.m_poJsonObject));
++    m_poJsonObject = gdal__json_object_get(TO_JSONOBJ(other.m_poJsonObject));
+     return *this;
+ }
+
+@@ -762,7 +762,7 @@ void CPLJSONObject::Add(const std::string &osName, const CPLJSONArray &oValue)
+     {
+         json_object_object_add(
+             TO_JSONOBJ(object.GetInternalHandle()), objectName.c_str(),
+-            json_object_get(TO_JSONOBJ(oValue.GetInternalHandle())));
++            gdal__json_object_get(TO_JSONOBJ(oValue.GetInternalHandle())));
+     }
+ }
+
+@@ -782,7 +782,7 @@ void CPLJSONObject::Add(const std::string &osName, const CPLJSONObject &oValue)
+     {
+         json_object_object_add(
+             TO_JSONOBJ(GetInternalHandle()), "",
+-            json_object_get(TO_JSONOBJ(oValue.GetInternalHandle())));
++            gdal__json_object_get(TO_JSONOBJ(oValue.GetInternalHandle())));
+         return;
+     }
+     CPLJSONObject object = GetObjectByPath(osName, objectName);
+@@ -791,7 +791,7 @@ void CPLJSONObject::Add(const std::string &osName, const CPLJSONObject &oValue)
+     {
+         json_object_object_add(
+             TO_JSONOBJ(object.GetInternalHandle()), objectName.c_str(),
+-            json_object_get(TO_JSONOBJ(oValue.GetInternalHandle())));
++            gdal__json_object_get(TO_JSONOBJ(oValue.GetInternalHandle())));
+     }
+ }
+
+@@ -812,7 +812,7 @@ void CPLJSONObject::AddNoSplitName(const std::string &osName,
+     {
+         json_object_object_add(
+             TO_JSONOBJ(GetInternalHandle()), osName.c_str(),
+-            json_object_get(TO_JSONOBJ(oValue.GetInternalHandle())));
++            gdal__json_object_get(TO_JSONOBJ(oValue.GetInternalHandle())));
+     }
+ }
+
+@@ -1479,7 +1479,7 @@ void CPLJSONArray::Add(const CPLJSONObject &oValue)
+     if (m_poJsonObject && oValue.m_poJsonObject)
+         json_object_array_add(
+             TO_JSONOBJ(m_poJsonObject),
+-            json_object_get(TO_JSONOBJ(oValue.m_poJsonObject)));
++            gdal__json_object_get(TO_JSONOBJ(oValue.m_poJsonObject)));
+ }
+
+ /**


### PR DESCRIPTION
At MotherDuck, we build and statically link DuckDB extensions on our server. Since Iceberg has a dependency on Avro, we also have to like the Avro extension on the server. Unfortunately, this leads to a conflict for duplicate symbols, namely `json_object_get` when linking both _duckdb-spatial_ and _duckdb-avro_.

This issue stems from the inclusion of the `jansson` library in avro and the `gdal` library in spatial.


Both libraries define a `jsob_object_get` function (see https://github.com/akheron/jansson/blob/96d160df90016066d04d493d1d69639474ba4f20/src/jansson.h#L189 and https://github.com/OSGeo/gdal/blob/9c6652c257799b88ca83302c3368545aba869c65/ogr/ogrsf_frmts/geojson/libjson/json_object.h#L348).

---

This PR patches the `json_object_get` function in `gdal` by renaming it to `gdal__json_object_get`.