### PR TITLE
Fix spatial join with empty geometries on build-side, misc formatting fixes. 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,11 @@
+---
 BasedOnStyle: LLVM
+SortIncludes: false
 TabWidth: 4
 IndentWidth: 4
+ColumnLimit: 120
+AllowShortFunctionsOnASingleLine: false
+---
 UseTab: ForIndentation
 DerivePointerAlignment: false
 PointerAlignment: Right
@@ -16,11 +21,14 @@ SpaceBeforeInheritanceColon: true
 SpacesInAngles: false
 SpacesInCStyleCastParentheses: false
 SpacesInConditionalStatement: false
-AllowShortFunctionsOnASingleLine: false
 AllowShortLambdasOnASingleLine: Inline
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: Yes
-ColumnLimit: 120
 IncludeBlocks: Regroup
 Language: Cpp
 AccessModifierOffset: -4
+CommentPragmas:  '^[^ ]'
+---
+Language: Java
+SpaceAfterCStyleCast: true
+---

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -11,7 +11,7 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)
 endif()
 
-if(${VCPKG_TARGET_TRIPLET} STREQUAL "wasm32-emscripten")
+if("${VCPKG_TARGET_TRIPLET}" STREQUAL "wasm32-emscripten")
     set(EMSCRIPTEN ON)
 endif()
 

--- a/src/spatial/index/rtree/rtree_index_create_logical.cpp
+++ b/src/spatial/index/rtree/rtree_index_create_logical.cpp
@@ -281,14 +281,13 @@ void LogicalCreateRTreeIndex::Serialize(Serializer &writer) const {
 	LogicalExtensionOperator::Serialize(writer);
 	writer.WritePropertyWithDefault(300, "operator_type", string(OPERATOR_TYPE_NAME));
 	writer.WritePropertyWithDefault<unique_ptr<CreateIndexInfo>>(400, "info", info);
-	writer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(401, "unbound_expressions",
-																	unbound_expressions);
+	writer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(401, "unbound_expressions", unbound_expressions);
 }
 
 unique_ptr<LogicalExtensionOperator> LogicalCreateRTreeIndex::Deserialize(Deserializer &reader) {
 	auto create_info = reader.ReadPropertyWithDefault<unique_ptr<CreateInfo>>(400, "info");
 	auto unbound_expressions =
-		reader.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(401, "unbound_expressions");
+	    reader.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(401, "unbound_expressions");
 
 	auto info = unique_ptr_cast<CreateInfo, CreateIndexInfo>(std::move(create_info));
 
@@ -301,7 +300,7 @@ unique_ptr<LogicalExtensionOperator> LogicalCreateRTreeIndex::Deserialize(Deseri
 
 	// Return the new operator
 	return make_uniq_base<LogicalExtensionOperator, LogicalCreateRTreeIndex>(
-		std::move(info), std::move(unbound_expressions), table_entry);
+	    std::move(info), std::move(unbound_expressions), table_entry);
 }
 
 } // namespace duckdb

--- a/src/spatial/index/rtree/rtree_index_create_logical.hpp
+++ b/src/spatial/index/rtree/rtree_index_create_logical.hpp
@@ -32,6 +32,7 @@ public:
 public:
 	void Serialize(Serializer &writer) const override;
 	static unique_ptr<LogicalExtensionOperator> Deserialize(Deserializer &reader);
+
 public:
 	string GetName() const override {
 		return "CREATE_RTREE_INDEX";

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -1294,7 +1294,6 @@ struct ST_Read_Meta {
 				continue;
 			}
 
-
 			output.data[0].SetValue(output_idx, file.path);
 			output.data[1].SetValue(output_idx, dataset->GetDriver()->GetDescription());
 			output.data[2].SetValue(output_idx, dataset->GetDriver()->GetMetadataItem(GDAL_DMD_LONGNAME));

--- a/src/spatial/modules/shapefile/shapefile_module.cpp
+++ b/src/spatial/modules/shapefile/shapefile_module.cpp
@@ -283,9 +283,8 @@ struct ST_ReadSHP {
 		vector<LogicalType> attribute_types;
 
 		explicit ShapefileBindData(string file_name_p)
-		    : file_name(std::move(file_name_p)), shape_count(0),
-		      shape_type(0), min_bound {0, 0, 0, 0}, max_bound {0, 0, 0, 0},
-		      attribute_encoding(AttributeEncoding::LATIN1) {
+		    : file_name(std::move(file_name_p)), shape_count(0), shape_type(0), min_bound {0, 0, 0, 0},
+		      max_bound {0, 0, 0, 0}, attribute_encoding(AttributeEncoding::LATIN1) {
 		}
 	};
 

--- a/src/spatial/operators/spatial_join_logical.cpp
+++ b/src/spatial/operators/spatial_join_logical.cpp
@@ -69,14 +69,14 @@ void LogicalSpatialJoin::ResolveTypes() {
 	types.insert(types.end(), right_types.begin(), right_types.end());
 }
 
-PhysicalOperator& LogicalSpatialJoin::CreatePlan(ClientContext &context, PhysicalPlanGenerator &generator) {
+PhysicalOperator &LogicalSpatialJoin::CreatePlan(ClientContext &context, PhysicalPlanGenerator &generator) {
 
 	// Return a new PhysicalSpatialJoin operator
 	auto &left = generator.CreatePlan(*children[0]);
 	auto &right = generator.CreatePlan(*children[1]);
 
-	return generator.Make<PhysicalSpatialJoin>(
-	    *this, left, right, std::move(spatial_predicate), join_type, estimated_cardinality);
+	return generator.Make<PhysicalSpatialJoin>(*this, left, right, std::move(spatial_predicate), join_type,
+	                                           estimated_cardinality);
 }
 
 void LogicalSpatialJoin::Serialize(Serializer &writer) const {

--- a/src/spatial/operators/spatial_join_logical.hpp
+++ b/src/spatial/operators/spatial_join_logical.hpp
@@ -39,11 +39,12 @@ public:
 		return !left_projection_map.empty() || !right_projection_map.empty();
 	}
 
-	PhysicalOperator& CreatePlan(ClientContext &context, PhysicalPlanGenerator &generator) override;
+	PhysicalOperator &CreatePlan(ClientContext &context, PhysicalPlanGenerator &generator) override;
 
 public:
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<LogicalExtensionOperator> Deserialize(Deserializer &reader);
+
 public:
 	string GetName() const override {
 		return "SPATIAL_JOIN";
@@ -51,6 +52,7 @@ public:
 	string GetExtensionName() const override {
 		return "duckdb_spatial";
 	}
+
 protected:
 	void ResolveTypes() override;
 };

--- a/src/spatial/operators/spatial_operator_extension.cpp
+++ b/src/spatial/operators/spatial_operator_extension.cpp
@@ -35,7 +35,7 @@ public:
 		}
 
 		throw SerializationException("This version of the spatial extension does not support operator type '%s!",
-										 operator_type);
+		                             operator_type);
 	}
 };
 
@@ -45,4 +45,4 @@ void RegisterSpatialOperatorExtension(DatabaseInstance &db) {
 	db.config.operator_extensions.push_back(make_uniq<SpatialOperatorExtension>());
 }
 
-}
+} // namespace duckdb

--- a/src/spatial/operators/spatial_operator_extension.hpp
+++ b/src/spatial/operators/spatial_operator_extension.hpp
@@ -5,4 +5,4 @@ namespace duckdb {
 class DatabaseInstance;
 void RegisterSpatialOperatorExtension(DatabaseInstance &db);
 
-}
+} // namespace duckdb

--- a/src/spatial/spatial_extension.cpp
+++ b/src/spatial/spatial_extension.cpp
@@ -46,7 +46,8 @@ static void LoadInternal(DatabaseInstance &instance) {
 	RTreeModule::RegisterIndexScan(instance);
 	RTreeModule::RegisterIndexPlanScan(instance);
 
-	RegisterSpatialOperatorExtension(instance);;
+	RegisterSpatialOperatorExtension(instance);
+	;
 }
 
 void SpatialExtension::Load(DuckDB &db) {

--- a/test/sql/join/spatial_join_empty_build.test
+++ b/test/sql/join/spatial_join_empty_build.test
@@ -29,8 +29,8 @@ SELECT * FROM lhs JOIN rhs ON ST_Intersects(lhs.geom, rhs.geom);
 
 statement ok
 PRAGMA disabled_optimizers='extension'
-query IIII rowsort left_join_result
 
+query IIII rowsort left_join_result
 SELECT * FROM lhs LEFT JOIN rhs ON ST_Intersects(lhs.geom, rhs.geom);
 ----
 

--- a/test/sql/join/spatial_join_empty_build.test
+++ b/test/sql/join/spatial_join_empty_build.test
@@ -1,0 +1,36 @@
+require spatial
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE lhs AS
+SELECT
+    ST_Point(x, y) as geom,
+    (y * 50) + x // 10 as id
+FROM
+    generate_series(0, 500, 50) r1(x),
+    generate_series(0, 500, 50) r2(y);
+
+# Test joining with an empty RHS
+statement ok
+CREATE TABLE rhs (geom geometry, id integer);
+
+statement ok
+insert into rhs (VALUES
+    (ST_Point(0, 0), 1),
+    (ST_GeomFromText('MULTIPOLYGON EMPTY'), 2),
+    (ST_GeomFromText('GEOMETRYCOLLECTION EMPTY'), 3),
+    (ST_GeomFromText(NULL), 4));
+
+query IIII rowsort join_result
+SELECT * FROM lhs JOIN rhs ON ST_Intersects(lhs.geom, rhs.geom);
+----
+
+statement ok
+PRAGMA disabled_optimizers='extension'
+query IIII rowsort left_join_result
+
+SELECT * FROM lhs LEFT JOIN rhs ON ST_Intersects(lhs.geom, rhs.geom);
+----
+


### PR DESCRIPTION
Unfortunately this slipped through the cracks when testing, but we need to count how many non-null-non-empty geometries we got on the build side before we construct the r-tree, or the expected and actual size will differ, breaking the r-tree traversal. We now handle this when sinking into the local state during the build phase.

Also fixes a CMake issue when building without VCPKG, and updates the code style spec to latest duckdb.

Closes #580 
