### PR TITLE
feat: add PROJ version functions

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -126,6 +126,7 @@
 | [`ST_ZMFlag`](#st_zmflag) | Returns a flag indicating the presence of Z and M values in the input geometry. |
 | [`ST_ZMax`](#st_zmax) | Returns the maximum Z coordinate of a geometry |
 | [`ST_ZMin`](#st_zmin) | Returns the minimum Z coordinate of a geometry |
+| [`DuckDB_PROJ_Version`](#duckdb_proj_version) | Returns the current (runtime) version of the PROJ library. |
 
 **[Aggregate Functions](#aggregate-functions)**
 
@@ -2619,6 +2620,49 @@ Returns the minimum Z coordinate of a geometry
 
 ```sql
 SELECT ST_ZMin(ST_Point(1, 2, 3))
+```
+
+----
+
+### DuckDB_PROJ_Version
+
+
+#### Signature
+
+```sql
+VARCHAR DuckDB_PROJ_Version ()
+```
+
+#### Description
+
+Returns runtime version of the supporting PROJ library.
+
+#### Example
+
+```sql
+SELECT DuckDB_PROJ_Version()
+```
+
+----
+
+
+### DuckDB_PROJ_Compiled_Version
+
+
+#### Signature
+
+```sql
+VARCHAR DuckDB_PROJ_Compiled_Version ()
+```
+
+#### Description
+
+Returns compile-time version of the supporting PROJ library.
+
+#### Example
+
+```sql
+SELECT DuckDB_PROJ_Compiled_Version()
 ```
 
 ----


### PR DESCRIPTION
This is inspired by the similar PostGIS functions at https://postgis.net/docs/PostGIS_PROJ_Compiled_Version.html and https://postgis.net/docs/PostGIS_PROJ_Version.html

Based on spatialite experience, this is useful to work out "why do your numbers not quite match my numbers", although the motivation here is mainly as a simple implementation to check the process. So I'd like to make sure this really is a solid change, before working a more complex function.