### PR TITLE
Add `ST_Azimuth()`

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -12,6 +12,7 @@
 | [`ST_AsSVG`](#st_assvg) | Convert the geometry into a SVG fragment or path |
 | [`ST_AsText`](#st_astext) | Returns the geometry as a WKT string |
 | [`ST_AsWKB`](#st_aswkb) | Returns the geometry as a WKB (Well-Known-Binary) blob |
+| [`ST_Azimuth`](#st_azimuth) | Returns the azimuth in radian |
 | [`ST_Boundary`](#st_boundary) | Returns the "boundary" of a geometry |
 | [`ST_Buffer`](#st_buffer) | Returns a buffer around the input geometry at the target distance |
 | [`ST_BuildArea`](#st_buildarea) | Creates a polygonal geometry by attemtping to "fill in" the input geometry. |
@@ -343,6 +344,30 @@ Returns the geometry as a WKB (Well-Known-Binary) blob
 SELECT ST_AsWKB('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'::GEOMETRY)::BLOB;
 ----
 \x01\x03\x00\x00\x00\x01\x00\x00\x00\x05...
+```
+
+----
+
+### ST_Azimuth
+
+
+#### Signature
+
+```sql
+double ST_Azimuth (origin GEOMETRY, target GEOMETRY)
+double ST_Azimuth (origin POINT_2D, target POINT_2D)
+```
+
+#### Description
+
+Returns the azimuth (a clockwise angle measured from north) of two points in radian
+
+#### Example
+
+```sql
+SELECT degrees(ST_Azimuth(ST_Point(0, 0), ST_Point(0, 1)));
+----
+90.0
 ```
 
 ----

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -2174,27 +2174,7 @@ struct ST_Azimuth {
 
 			    const auto lv = lhs.get_vertex_xy(0);
 			    const auto rv = rhs.get_vertex_xy(0);
-
-			    // Check if points are coincident
-			    if (lv.x == rv.x && lv.y == rv.y) {
-				    return std::numeric_limits<double>::quiet_NaN();
-			    }
-
-				double angle = std::atan2(
-					rv.y - lv.y,
-					rv.x - lv.x
-				);
-
-				// atan2 returns angle from positive X axis, counter-clockwise while
-				// we want angle from positive Y axis, clockwise.
-				double azimuth = M_PI / 2.0 - angle;
-				
-				// ensure angle is positive
-				if (azimuth < 0) {
-					azimuth += 2.0 * M_PI;
-				}
-			    
-			    return azimuth;
+				return calcAngle(lv.x, lv.y, rv.x, rv.y);
 		    });
 	}
 
@@ -2228,33 +2208,30 @@ struct ST_Azimuth {
 				out_data[i] = std::numeric_limits<double>::quiet_NaN();
 				continue;
 			}
-
-			// Check if points are coincident
-			if (left_x[i] == right_x[i] && left_y[i] == right_y[i]) {
-				out_data[i] = std::numeric_limits<double>::quiet_NaN();
-				continue;
-			}
-
-			double angle = std::atan2(
-				right_y[i] - left_y[i],
-				right_x[i] - left_x[i]
-			);
-
-			// atan2 returns angle from positive X axis, counter-clockwise while
-			// we want angle from positive Y axis, clockwise.
-			double azimuth = M_PI / 2.0 - angle;
-			
-			// ensure angle is positive
-			if (azimuth < 0) {
-				azimuth += 2.0 * M_PI;
-			}
-			
-			out_data[i] = azimuth;
+			out_data[i] = calcAngle(left_x[i], left_y[i], right_x[i], right_y[i]);
 		}
 
 		if (count == 1) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		}
+	}
+
+	static double calcAngle(double x1, double y1, double x2, double y2) {
+		// Check if points are coincident
+		if (x1 == x2 && y1 == y2) {
+			return std::numeric_limits<double>::quiet_NaN();
+		}
+
+		// atan2 returns angle from positive X axis, counter-clockwise while
+		// we want angle from positive Y axis, clockwise.
+		double azimuth = M_PI / 2.0 - std::atan2(y2 - y1, x2 - x1);
+		
+		// ensure angle is positive
+		if (azimuth < 0) {
+			azimuth += 2.0 * M_PI;
+		}
+
+		return azimuth;
 	}
 
 	//------------------------------------------------------------------------------------------------------------------

--- a/test/sql/geometry/st_azimuth.test
+++ b/test/sql/geometry/st_azimuth.test
@@ -1,0 +1,73 @@
+# ST_Azimuth tests
+
+require spatial
+
+query I
+SELECT Degrees(ST_Azimuth(ST_Point(0, 0), ST_Point(1, 0)));
+----
+90.0
+
+query I
+SELECT Degrees(ST_Azimuth(ST_Point(0, 0), ST_Point(0, 1)));
+----
+0.0
+
+query I
+SELECT Degrees(ST_Azimuth(ST_Point(0, 0), ST_Point(-1, 0)));
+----
+270.0
+
+query I
+SELECT Degrees(ST_Azimuth(ST_Point(1, 1), ST_Point(2, 2)));
+----
+45.0
+
+# Coincident points should return NULL
+query I
+SELECT ST_Azimuth(ST_Point(1, 1), ST_Point(1, 1)) IS NULL;
+----
+true
+
+# NULL handling - NULLs should return NULL
+query I
+SELECT ST_Azimuth(NULL, ST_Point(1, 1)) IS NULL;
+----
+true
+
+query I
+SELECT ST_Azimuth(ST_Point(1, 1), NULL) IS NULL;
+----
+true
+
+query I
+SELECT ST_Azimuth(NULL, NULL) IS NULL;
+----
+true
+
+# POINT_2D type
+query I
+SELECT Degrees(ST_Azimuth(ST_Point2D(0, 0), ST_Point2D(1, 0)));
+----
+90.0
+
+# Empty geometries should return NULL
+query I
+SELECT ST_Azimuth('POINT EMPTY'::geometry, 'POINT(1 1)'::geometry) IS NULL;
+----
+true
+
+query I
+SELECT ST_Azimuth('POINT(1 1)'::geometry, 'POINT EMPTY'::geometry) IS NULL;
+----
+true
+
+# Non-point geometries should error
+statement error
+SELECT ST_Azimuth('LINESTRING(0 0, 1 1)'::geometry, 'POINT(1 1)'::geometry);
+----
+Invalid Input Error: ST_Azimuth only accepts POINT geometries
+
+statement error
+SELECT ST_Azimuth('POINT(0 0)'::geometry, 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::geometry);
+----
+Invalid Input Error: ST_Azimuth only accepts POINT geometries


### PR DESCRIPTION
This pull request implements [`ST_Azimuth()`](https://postgis.net/docs/en/ST_Azimuth.html).

I'm not sure if this is very common function considering there's only [one feature request in Discussions](https://github.com/duckdb/duckdb-spatial/discussions/418), but I found I need this.

```sql
SELECT degrees(ST_Azimuth(ST_Point(0, 0), ST_Point(0, 1)));
----
90.0
```

(Maybe I should retry this after #588 gets merged...?)