### PR TITLE
Add support for `ST_DWithin` in `SPATIAL_JOIN`

### DIFF
--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -16,6 +16,8 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/vector_operations/septenary_executor.hpp"
 
+#include "spatial/util/distance_extract.hpp"
+
 // Extra
 #include "yyjson.h"
 
@@ -8561,6 +8563,18 @@ struct ST_MMin : VertexAggFunctionBase<ST_MMin, VertexMinAggOp> {
 };
 
 } // namespace
+
+// Helper to access the constant distance from the bind data
+bool ST_DWithinHelper::TryGetConstDistance(const unique_ptr<FunctionData> &bind_data, double &result) {
+	if (bind_data) {
+		const auto &data = bind_data->Cast<ST_DistanceWithin::BindData>();
+		if (data.is_constant) {
+			result = data.distance;
+			return true;
+		}
+	}
+	return false;
+}
 
 //######################################################################################################################
 // Register

--- a/src/spatial/operators/spatial_join_logical.hpp
+++ b/src/spatial/operators/spatial_join_logical.hpp
@@ -28,6 +28,9 @@ public:
 	//! Join Keys statistics (optional)
 	vector<unique_ptr<BaseStatistics>> join_stats;
 
+	bool has_const_distance = false;
+	double const_distance = 0.0;
+
 public:
 	explicit LogicalSpatialJoin(JoinType join_type_p);
 

--- a/src/spatial/operators/spatial_join_physical.cpp
+++ b/src/spatial/operators/spatial_join_physical.cpp
@@ -330,9 +330,9 @@ private:
 
 PhysicalSpatialJoin::PhysicalSpatialJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
                                          unique_ptr<Expression> condition_p, JoinType join_type,
-                                         idx_t estimated_cardinality)
+                                         idx_t estimated_cardinality, bool has_const_distance, double const_distance)
     : PhysicalJoin(op, PhysicalOperatorType::EXTENSION, join_type, estimated_cardinality),
-      condition(std::move(condition_p)) {
+      condition(std::move(condition_p)), has_const_distance(has_const_distance), const_distance(const_distance) {
 
 	children.emplace_back(left);
 	children.emplace_back(right);
@@ -634,6 +634,15 @@ SinkFinalizeType PhysicalSpatialJoin::Finalize(Pipeline &pipeline, Event &event,
 			if (!geom.TryGetCachedBounds(bbox)) {
 				// Skip empty geometries
 				continue;
+			}
+
+			if (has_const_distance) {
+				// If this is a ST_DWithin join, we need to expand the bounding box by the constant distance
+				const auto f_dist = MathUtil::DoubleToFloatUp(const_distance);
+				bbox.min.x -= f_dist;
+				bbox.min.y -= f_dist;
+				bbox.max.x += f_dist;
+				bbox.max.y += f_dist;
 			}
 
 			// Push the bounding box into the R-Tree

--- a/src/spatial/operators/spatial_join_physical.hpp
+++ b/src/spatial/operators/spatial_join_physical.hpp
@@ -11,7 +11,8 @@ public:
 
 public:
 	PhysicalSpatialJoin(LogicalOperator &op, PhysicalOperator &left, PhysicalOperator &right,
-	                    unique_ptr<Expression> spatial_predicate, JoinType join_type, idx_t estimated_cardinality);
+	                    unique_ptr<Expression> spatial_predicate, JoinType join_type, idx_t estimated_cardinality,
+	                    bool has_const_distance, double const_distance);
 
 	//! The condition of the join
 	unique_ptr<Expression> condition;
@@ -30,6 +31,10 @@ public:
 
 	shared_ptr<TupleDataLayout> layout;
 	idx_t build_side_match_offset = 0; // This is the byte offset to the match column for right/outer joins
+
+	// In case this is a ST_DWithin join, we store the constant distance here
+	bool has_const_distance = false;
+	double const_distance = 0.0;
 
 public:
 	// Operator Interface

--- a/src/spatial/util/distance_extract.hpp
+++ b/src/spatial/util/distance_extract.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace duckdb {
+
+struct FunctionData;
+
+// Helper class to extract the constant distance from the ST_DWithin function.
+struct ST_DWithinHelper {
+	static bool TryGetConstDistance(const unique_ptr<FunctionData> &bind_data, double &result);
+};
+
+} // namespace duckdb


### PR DESCRIPTION
Now that `ST_Distance` and `ST_DWithin` are much faster, it makes even more sense to support distance joins in the spatial join operator. However, the third `distance` argument needs to be constant for this optimization to apply.