### PR TITLE
SGL: improve linestring/linestring and polygon/polygon distance by indexing

### DIFF
--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -2529,8 +2529,8 @@ struct ST_Distance {
 			const auto &lhs_blob = ConstantVector::GetData<string_t>(lhs_vec)[0];
 			const auto &rhs_blob = ConstantVector::GetData<string_t>(rhs_vec)[0];
 
-			sgl::geometry lhs_geom;
-			sgl::geometry rhs_geom;
+			sgl::prepared_geometry lhs_geom;
+			sgl::prepared_geometry rhs_geom;
 
 			lstate.Deserialize(lhs_blob, lhs_geom);
 			lstate.Deserialize(rhs_blob, rhs_geom);
@@ -2553,7 +2553,7 @@ struct ST_Distance {
 			lstate.Deserialize(const_blob, const_geom);
 
 			UnaryExecutor::Execute<string_t, double>(probe_vec, result, count, [&](const string_t &probe_blob) {
-				sgl::geometry probe_geom;
+				sgl::prepared_geometry probe_geom;
 				lstate.Deserialize(probe_blob, probe_geom);
 
 				// Calculate the distance
@@ -2567,8 +2567,8 @@ struct ST_Distance {
 			// Both are non-const
 			BinaryExecutor::Execute<string_t, string_t, double>(
 			    args.data[0], args.data[1], result, count, [&](const string_t &blob1, const string_t &blob2) {
-				    sgl::geometry geom1;
-				    sgl::geometry geom2;
+				    sgl::prepared_geometry geom1;
+				    sgl::prepared_geometry geom2;
 
 				    lstate.Deserialize(blob1, geom1);
 				    lstate.Deserialize(blob2, geom2);
@@ -2756,7 +2756,7 @@ struct ST_DistanceWithin {
 				lstate.Deserialize(const_blob, const_geom);
 
 				UnaryExecutor::Execute<string_t, bool>(probe_vec, result, count, [&](const string_t &probe_blob) {
-					sgl::geometry probe_geom;
+					sgl::prepared_geometry probe_geom;
 					lstate.Deserialize(probe_blob, probe_geom);
 
 					// Calculate the distance

--- a/src/spatial/modules/mvt/mvt_module.cpp
+++ b/src/spatial/modules/mvt/mvt_module.cpp
@@ -21,41 +21,41 @@ namespace {
 
 class LocalState final : public FunctionLocalState {
 public:
-    explicit LocalState(ClientContext &context) : arena(BufferAllocator::Get(context)), allocator(arena) {
-    }
+	explicit LocalState(ClientContext &context) : arena(BufferAllocator::Get(context)), allocator(arena) {
+	}
 
-    static unique_ptr<FunctionLocalState> Init(ExpressionState &state, const BoundFunctionExpression &expr,
-                                               FunctionData *bind_data);
-    static LocalState &ResetAndGet(ExpressionState &state);
+	static unique_ptr<FunctionLocalState> Init(ExpressionState &state, const BoundFunctionExpression &expr,
+	                                           FunctionData *bind_data);
+	static LocalState &ResetAndGet(ExpressionState &state);
 
-    string_t Serialize(Vector &vector, const sgl::geometry &geom);
+	string_t Serialize(Vector &vector, const sgl::geometry &geom);
 
-    GeometryAllocator &GetAllocator() {
-        return allocator;
-    }
+	GeometryAllocator &GetAllocator() {
+		return allocator;
+	}
 
 private:
-    ArenaAllocator arena;
-    GeometryAllocator allocator;
+	ArenaAllocator arena;
+	GeometryAllocator allocator;
 };
 
 unique_ptr<FunctionLocalState> LocalState::Init(ExpressionState &state, const BoundFunctionExpression &expr,
                                                 FunctionData *bind_data) {
-    return make_uniq_base<FunctionLocalState, LocalState>(state.GetContext());
+	return make_uniq_base<FunctionLocalState, LocalState>(state.GetContext());
 }
 
 LocalState &LocalState::ResetAndGet(ExpressionState &state) {
-    auto &local_state = ExecuteFunctionState::GetFunctionState(state)->Cast<LocalState>();
-    local_state.arena.Reset();
-    return local_state;
+	auto &local_state = ExecuteFunctionState::GetFunctionState(state)->Cast<LocalState>();
+	local_state.arena.Reset();
+	return local_state;
 }
 
 string_t LocalState::Serialize(Vector &vector, const sgl::geometry &geom) {
-    const auto size = Serde::GetRequiredSize(geom);
-    auto blob = StringVector::EmptyString(vector, size);
-    Serde::Serialize(geom, blob.GetDataWriteable(), size);
-    blob.Finalize();
-    return blob;
+	const auto size = Serde::GetRequiredSize(geom);
+	auto blob = StringVector::EmptyString(vector, size);
+	Serde::Serialize(geom, blob.GetDataWriteable(), size);
+	blob.Finalize();
+	return blob;
 }
 
 } // namespace
@@ -63,64 +63,64 @@ string_t LocalState::Serialize(Vector &vector, const sgl::geometry &geom) {
 namespace {
 
 struct ST_TileEnvelope {
-    static constexpr double RADIUS = 6378137.0;
-    static constexpr double PI = 3.141592653589793;
-    static constexpr double CIRCUMFERENCE = 2 * PI * RADIUS;
+	static constexpr double RADIUS = 6378137.0;
+	static constexpr double PI = 3.141592653589793;
+	static constexpr double CIRCUMFERENCE = 2 * PI * RADIUS;
 
-    static void ExecuteWebMercator(DataChunk &args, ExpressionState &state, Vector &result) {
-        auto &lstate = LocalState::ResetAndGet(state);
+	static void ExecuteWebMercator(DataChunk &args, ExpressionState &state, Vector &result) {
+		auto &lstate = LocalState::ResetAndGet(state);
 
-        TernaryExecutor::Execute<int32_t, int32_t, int32_t, string_t>(
-            args.data[0], args.data[1], args.data[2], result, args.size(),
-            [&](int32_t tile_zoom, int32_t tile_x, int32_t tile_y) {
-                validate_tile_zoom_argument(tile_zoom);
-                uint32_t zoom_extent = 1u << tile_zoom;
-                validate_tile_index_arguments(zoom_extent, tile_x, tile_y);
-                sgl::geometry bbox;
-                get_tile_bbox(lstate.GetAllocator(), zoom_extent, tile_x, tile_y, bbox);
-                return lstate.Serialize(result, bbox);
-            });
-    }
+		TernaryExecutor::Execute<int32_t, int32_t, int32_t, string_t>(
+		    args.data[0], args.data[1], args.data[2], result, args.size(),
+		    [&](int32_t tile_zoom, int32_t tile_x, int32_t tile_y) {
+			    validate_tile_zoom_argument(tile_zoom);
+			    uint32_t zoom_extent = 1u << tile_zoom;
+			    validate_tile_index_arguments(zoom_extent, tile_x, tile_y);
+			    sgl::geometry bbox;
+			    get_tile_bbox(lstate.GetAllocator(), zoom_extent, tile_x, tile_y, bbox);
+			    return lstate.Serialize(result, bbox);
+		    });
+	}
 
-    static void validate_tile_zoom_argument(int32_t tile_zoom) {
-        if ((tile_zoom < 0) || (tile_zoom > 30)) {
-            throw InvalidInputException("ST_TileEnvelope: tile_zoom must be in the range [0,30]");
-        }
-    }
+	static void validate_tile_zoom_argument(int32_t tile_zoom) {
+		if ((tile_zoom < 0) || (tile_zoom > 30)) {
+			throw InvalidInputException("ST_TileEnvelope: tile_zoom must be in the range [0,30]");
+		}
+	}
 
-    static void validate_tile_index_arguments(uint32_t zoom_extent, int32_t tile_x, int32_t tile_y) {
-        if ((tile_x < 0) || ((uint32_t)tile_x >= zoom_extent)) {
-            throw InvalidInputException("ST_TileEnvelope: tile_x is out of range for specified tile_zoom");
-        }
-        if ((tile_y < 0) || ((uint32_t)tile_y >= zoom_extent)) {
-            throw InvalidInputException("ST_TileEnvelope: tile_y is out of range for specified tile_zoom");
-        }
-    }
+	static void validate_tile_index_arguments(uint32_t zoom_extent, int32_t tile_x, int32_t tile_y) {
+		if ((tile_x < 0) || ((uint32_t)tile_x >= zoom_extent)) {
+			throw InvalidInputException("ST_TileEnvelope: tile_x is out of range for specified tile_zoom");
+		}
+		if ((tile_y < 0) || ((uint32_t)tile_y >= zoom_extent)) {
+			throw InvalidInputException("ST_TileEnvelope: tile_y is out of range for specified tile_zoom");
+		}
+	}
 
-    static void get_tile_bbox(GeometryAllocator &allocator, uint32_t zoom_extent,
-                              int32_t tile_x, int32_t tile_y, sgl::geometry &bbox) {
-        double single_tile_width = CIRCUMFERENCE / zoom_extent;
-        double single_tile_height = CIRCUMFERENCE / zoom_extent;
-        double tile_left = get_tile_left(tile_x, single_tile_width);
-        double tile_right = tile_left + single_tile_width;
-        double tile_top = get_tile_top(tile_y, single_tile_height);
-        double tile_bottom = tile_top - single_tile_height;
+	static void get_tile_bbox(GeometryAllocator &allocator, uint32_t zoom_extent, int32_t tile_x, int32_t tile_y,
+	                          sgl::geometry &bbox) {
+		double single_tile_width = CIRCUMFERENCE / zoom_extent;
+		double single_tile_height = CIRCUMFERENCE / zoom_extent;
+		double tile_left = get_tile_left(tile_x, single_tile_width);
+		double tile_right = tile_left + single_tile_width;
+		double tile_top = get_tile_top(tile_y, single_tile_height);
+		double tile_bottom = tile_top - single_tile_height;
 
-        sgl::polygon::init_from_bbox(allocator, tile_left, tile_bottom, tile_right, tile_top, bbox);
-    }
+		sgl::polygon::init_from_bbox(allocator, tile_left, tile_bottom, tile_right, tile_top, bbox);
+	}
 
-    static double get_tile_left(uint32_t tile_x, double single_tile_width) {
-        return -0.5 * CIRCUMFERENCE + (tile_x * single_tile_width);
-    }
+	static double get_tile_left(uint32_t tile_x, double single_tile_width) {
+		return -0.5 * CIRCUMFERENCE + (tile_x * single_tile_width);
+	}
 
-    static double get_tile_top(uint32_t tile_y, double single_tile_height) {
-        return 0.5 * CIRCUMFERENCE - (tile_y * single_tile_height);
-    }
+	static double get_tile_top(uint32_t tile_y, double single_tile_height) {
+		return 0.5 * CIRCUMFERENCE - (tile_y * single_tile_height);
+	}
 
-    //------------------------------------------------------------------------------------------------------------------
-    // Documentation
-    //------------------------------------------------------------------------------------------------------------------
-    static constexpr auto DESCRIPTION = R"(
+	//------------------------------------------------------------------------------------------------------------------
+	// Documentation
+	//------------------------------------------------------------------------------------------------------------------
+	static constexpr auto DESCRIPTION = R"(
         The `ST_TileEnvelope` scalar function generates tile envelope rectangular polygons from specified zoom level and tile indices.
 
         This is used in MVT generation to select the features corresponding to the tile extent. The envelope is in the Web Mercator
@@ -134,7 +134,7 @@ struct ST_TileEnvelope {
         SELECT ST_TileEnvelope(2, 3, 1);
         ```
     )";
-    static constexpr auto EXAMPLE = R"(
+	static constexpr auto EXAMPLE = R"(
         SELECT ST_TileEnvelope(2, 3, 1);
         ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
         │                                         st_tileenvelope(2, 3, 1)                                          │
@@ -144,27 +144,27 @@ struct ST_TileEnvelope {
         └───────────────────────────────────────────────────────────────────────────────────────────────────────────┘
     )";
 
-    //------------------------------------------------------------------------------------------------------------------
-    // Register
-    //------------------------------------------------------------------------------------------------------------------
-    static void Register(DatabaseInstance &db) {
-        FunctionBuilder::RegisterScalar(db, "ST_TileEnvelope", [](ScalarFunctionBuilder &func) {
-            func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
-                variant.AddParameter("tile_zoom", LogicalType::INTEGER);
-                variant.AddParameter("tile_x", LogicalType::INTEGER);
-                variant.AddParameter("tile_y", LogicalType::INTEGER);
-                variant.SetReturnType(GeoTypes::GEOMETRY());
-                variant.SetInit(LocalState::Init);
-                variant.SetFunction(ExecuteWebMercator);
-            });
+	//------------------------------------------------------------------------------------------------------------------
+	// Register
+	//------------------------------------------------------------------------------------------------------------------
+	static void Register(DatabaseInstance &db) {
+		FunctionBuilder::RegisterScalar(db, "ST_TileEnvelope", [](ScalarFunctionBuilder &func) {
+			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
+				variant.AddParameter("tile_zoom", LogicalType::INTEGER);
+				variant.AddParameter("tile_x", LogicalType::INTEGER);
+				variant.AddParameter("tile_y", LogicalType::INTEGER);
+				variant.SetReturnType(GeoTypes::GEOMETRY());
+				variant.SetInit(LocalState::Init);
+				variant.SetFunction(ExecuteWebMercator);
+			});
 
-            func.SetDescription(DESCRIPTION);
-            func.SetExample(EXAMPLE);
+			func.SetDescription(DESCRIPTION);
+			func.SetExample(EXAMPLE);
 
-            func.SetTag("ext", "spatial");
-            func.SetTag("category", "conversion");
-        });
-    }
+			func.SetTag("ext", "spatial");
+			func.SetTag("category", "conversion");
+		});
+	}
 };
 
 } // namespace
@@ -172,7 +172,7 @@ struct ST_TileEnvelope {
 //  Register
 //------------------------------------------------------------------------------
 void RegisterMapboxVectorTileModule(DatabaseInstance &db) {
-    ST_TileEnvelope::Register(db);
+	ST_TileEnvelope::Register(db);
 };
 
 } // namespace duckdb

--- a/src/spatial/spatial_types.cpp
+++ b/src/spatial/spatial_types.cpp
@@ -50,7 +50,8 @@ LogicalType GeoTypes::LINESTRING_2D() {
 }
 
 LogicalType GeoTypes::LINESTRING_3D() {
-	auto type = LogicalType::LIST(LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}}));
+	auto type = LogicalType::LIST(
+	    LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}}));
 	type.SetAlias("LINESTRING_3D");
 	return type;
 }
@@ -63,8 +64,8 @@ LogicalType GeoTypes::POLYGON_2D() {
 }
 
 LogicalType GeoTypes::POLYGON_3D() {
-	auto type = LogicalType::LIST(
-	    LogicalType::LIST(LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}})));
+	auto type = LogicalType::LIST(LogicalType::LIST(
+	    LogicalType::STRUCT({{"x", LogicalType::DOUBLE}, {"y", LogicalType::DOUBLE}, {"z", LogicalType::DOUBLE}})));
 	type.SetAlias("POLYGON_3D");
 	return type;
 }


### PR DESCRIPTION
This PR greatly improves performance of `ST_Distance` and `ST_DWithin` between combinations of linestring/linestring, polygon/polygon and linestring/polygon, by making use of prepared (indexed) vertex arrays. The trick is to discard candidate segments by comparing the distance between the bounding boxes formed by their start and endpoints, before computing the costly segment/segment distance check.

The code in SGL is getting a bit messy though, I really need to commit to adding a `segment_xy` class of some sort. But more related to this PR we could probably shave off another ~5% by caching the priority queue, so we should look into refactoring the distance computation part into a stateful struct/class that we can reuse, and template to compute e.g. "shortest line", "max distance", and spheroid distance.

Also ran `make format`. 