### PR TITLE
Update MainDistributionPipeline.yml: branches, no tags

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -41,4 +41,4 @@ jobs:
       duckdb_version: v1.3.1
       ci_tools_version: main
       extension_name: spatial
-      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+      deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
I think problem is that on `v1.3.1` (and likely on other branches as well), extension is never actually deployed (given it's not a tag and it's not a branch called `main`.

This attempts at fixing this.

CI here basically only checks the syntax.