### PR TITLE
Don't call memcpy with NULL src

### DIFF
--- a/src/spatial/geometry/geometry_serialization.cpp
+++ b/src/spatial/geometry/geometry_serialization.cpp
@@ -102,7 +102,9 @@ static void SerializeVertices(BinaryWriter &cursor, const sgl::geometry *geom, c
 
 	if (!has_bbox) {
 		// Fast path, issue on memcpy to the cursor
-		memcpy(dst, verts, count * vsize);
+		if (count * vsize != 0) {
+			memcpy(dst, verts, count * vsize);
+		}
 		return;
 	}
 


### PR DESCRIPTION
When running tests locally I got this error consistently (I used GCC 13):

```
[3/104] (2%): /home/jelte/work/duckdb-spatial/test/sql/geos/centroid.test       /home/jelte/work/duckdb-spatial/src/spatial/geometry/geometry_serialization.cpp:105:9: runtime error: null pointer passed as argument 2, which is declared to never be null
```

The error goes away with the change is this PR. So the reason for this failure seems to be that (annoyingly) `memcpy` is defined as having undefined behaviour if `src` is null, even if the number of bytes to be copied is 0. With this change we simply don't call `memcpy` in that case at all, thus avoiding the undefined behaviour.
