### PR TITLE
Fixup linking of libraries for Wasm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,13 @@ set(TARGET_NAME spatial)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(CMAKE_CXX_STANDARD 11)
 
+if (EMSCRIPTEN)
+  # _LINKED_LIBS influences only Wasm compilation
+  # it's unclear why this is needed, but somehow the global symbol pj_release from PROJ is not properly exported otherwise
+  # this solves by basically re-linking (at the moment the Wasm binary is actually produced)
+  set (DUCKDB_EXTENSION_SPATIAL_LINKED_LIBS "../../vcpkg_installed/wasm32-emscripten/lib/lib*.a")
+endif()
+
 project(${TARGET_NAME})
 
 add_definitions(-DDUCKDB_MAJOR_VERSION=${DUCKDB_MAJOR_VERSION})


### PR DESCRIPTION
It's unclear to me why the symbol `pj_release` do not get properly exported to the final binary in Wasm, and I don't have a fix in PROJ, but this solves the problem (basically by re-linking the libraries again).

This is behind an `EMSCRIPTEN` ifdef, so should be sort of safe.