### PR TITLE
Allow overwriting C++ version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # Set extension name here
 set(TARGET_NAME spatial)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard")
 
 if(EMSCRIPTEN)
   # _LINKED_LIBS influences only Wasm compilation it's unclear why this is


### PR DESCRIPTION
Makes CMAKE_CXX_STANDARD a cached variable so that it is possible to overwrite the C++ version with which it is build from a parent CMake project or the command line CMake call.