### PR TITLE
Add debug build to spatial CI

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -42,3 +42,12 @@ jobs:
       ci_tools_version: v1.4-andium
       extension_name: spatial
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
+
+  duckdb-relassert-build:
+    name: Build extension binaries - relassert
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4-andium
+    with:
+      duckdb_version: v1.4.3
+      ci_tools_version: v1.4-andium
+      extension_name: spatial
+      build_type: relassert


### PR DESCRIPTION
Attempt at checking whether this separate configuration would help catch CI issues.

Open questions:
1. does it work, as in actually expand what's tested?
2. does it make so the uploaded extensions will be mixed up?

Second one is the most problematic, since it can introduce a new class of issues, to be reviewed properly after CI goes through.