### PR TITLE
fix: ST_Distance_Sphere::BindData::Copy std::move for GCC 11+

### DIFF
--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -5784,7 +5784,7 @@ struct ST_Distance_Sphere {
 		unique_ptr<FunctionData> Copy() const override {
 			auto copy = make_uniq<BindData>();
 			copy->always_xy = always_xy;
-			return copy;
+			return std::move(copy);
 		}
 		bool Equals(const FunctionData &other) const override {
 			auto &other_bind = other.Cast<BindData>();


### PR DESCRIPTION
`ST_Distance_Sphere::BindData::Copy()` returns `unique_ptr<FunctionData>`, but constructs `unique_ptr<BindData>` internally. Returning `copy` directly relies on an implicit derived-to-base `unique_ptr` conversion that newer GCC (11+) rejects in a return statement without an explicit `std::move`:

```
error: could not convert 'copy' from
  'unique_ptr<duckdb::{anonymous}::ST_Distance_Sphere::BindData, ...>'
  to 'unique_ptr<duckdb::FunctionData, ...>'
```

The fix is a one-line change wrapping the return in `std::move()`.

### Diff

```cpp
 unique_ptr<FunctionData> Copy() const override {
     auto copy = make_uniq<BindData>();
     copy->always_xy = always_xy;
-    return copy;
+    return std::move(copy);
 }
```

### Scope

- 1 file changed, 1 insertion, 1 deletion
- No behavior change — purely a compilation fix
- Unblocks building on Ubuntu 22.04 / Debian 12 (GCC 11+) out of the box

### Verification

- Built on GCC 11.4.0 (Ubuntu 22.04), no warnings
- All existing spatial tests pass (`test/sql/join/*`, `test/sql/geometry/*`, `test/sql/geos/*`)