### PR TITLE
Fix spatial for duckdb main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=spatial
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
+T ?= --batch-size 1 --batch-timeout 300
+
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 

--- a/src/spatial/index/rtree/rtree_index.cpp
+++ b/src/spatial/index/rtree/rtree_index.cpp
@@ -112,13 +112,13 @@ RTreeIndex::RTreeIndex(const string &name, IndexConstraintType index_constraint_
 	auto &source_type = unbound_expressions[0]->GetReturnType();
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_Extent_Approx");
-	auto func = entry.functions.GetFunctionByArguments(context, {source_type});
+	const auto &func = entry.functions.GetFunctionByArguments(context, {source_type});
 	auto child_expr = make_uniq<BoundReferenceExpression>(source_type, 0);
 
 	vector<unique_ptr<Expression>> children;
 	children.push_back(std::move(child_expr));
 
-	key_expr = make_uniq<BoundFunctionExpression>(GeoTypes::BOX_2DF(), func, std::move(children), nullptr);
+	key_expr = func.Bind(context, std::move(children));
 	key_executor = make_uniq<ExpressionExecutor>(context);
 	key_executor->AddExpression(*key_expr);
 	key_chunk.Initialize(context, {GeoTypes::BOX_2DF()});

--- a/src/spatial/index/rtree/rtree_index.cpp
+++ b/src/spatial/index/rtree/rtree_index.cpp
@@ -159,7 +159,7 @@ idx_t RTreeIndex::Scan(IndexScanState &state, Vector &result) const {
 	return output_idx;
 }
 
-void RTreeIndex::CommitDrop(IndexLock &index_lock) {
+void RTreeIndex::ResetStorage(IndexLock &index_lock) {
 	// TODO: Maybe we can drop these much earlier?
 	tree->Reset();
 }

--- a/src/spatial/index/rtree/rtree_index.cpp
+++ b/src/spatial/index/rtree/rtree_index.cpp
@@ -109,7 +109,7 @@ RTreeIndex::RTreeIndex(const string &name, IndexConstraintType index_constraint_
 	}
 
 	// Construct the key expression executor
-	auto &source_type = unbound_expressions[0]->return_type;
+	auto &source_type = unbound_expressions[0]->GetReturnType();
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_Extent_Approx");
 	auto func = entry.functions.GetFunctionByArguments(context, {source_type});

--- a/src/spatial/index/rtree/rtree_index.cpp
+++ b/src/spatial/index/rtree/rtree_index.cpp
@@ -136,7 +136,7 @@ unique_ptr<IndexScanState> RTreeIndex::InitializeScan(const RTreeBounds &query) 
 
 idx_t RTreeIndex::Scan(IndexScanState &state, Vector &result) const {
 	auto &sstate = state.Cast<RTreeIndexScanState>();
-	const auto row_ids = FlatVector::GetData<row_t>(result);
+	const auto row_ids = FlatVector::GetDataMutable<row_t>(result);
 
 	idx_t output_idx = 0;
 	sstate.scanner.Scan(*tree, [&](const RTreeEntry &entry, const idx_t &) {

--- a/src/spatial/index/rtree/rtree_index.hpp
+++ b/src/spatial/index/rtree/rtree_index.hpp
@@ -47,7 +47,7 @@ public:
 	ErrorData Append(IndexLock &lock, DataChunk &entries, Vector &row_identifiers) override;
 
 	//! Deletes all data from the index. The lock obtained from InitializeLock must be held
-	void CommitDrop(IndexLock &index_lock) override;
+	void ResetStorage(IndexLock &index_lock) override;
 	//! Delete a chunk of entries from the index. The lock obtained from InitializeLock must be held
 	void Delete(IndexLock &lock, DataChunk &entries, Vector &row_identifiers) override;
 	//! Insert a chunk of entries into the index

--- a/src/spatial/index/rtree/rtree_index_create_logical.cpp
+++ b/src/spatial/index/rtree/rtree_index_create_logical.cpp
@@ -151,7 +151,7 @@ PhysicalOperator &RTreeIndex::CreatePlan(PlanIndexInput &input) {
 	auto &expr = op.unbound_expressions[0];
 
 	// Validate that we have the right type of expression (float array)
-	if (expr->return_type != LogicalType::GEOMETRY()) {
+	if (expr->GetReturnType() != LogicalType::GEOMETRY()) {
 		throw BinderException("RTree indexes can only be created over GEOMETRY columns.");
 	}
 
@@ -167,7 +167,7 @@ PhysicalOperator &RTreeIndex::CreatePlan(PlanIndexInput &input) {
 
 	// Add the geometry expression to the select list
 	auto geom_expr = op.expressions[0]->Copy();
-	new_column_types.push_back(geom_expr->return_type);
+	new_column_types.push_back(geom_expr->GetReturnType());
 	select_list.push_back(std::move(geom_expr));
 
 	// Add the row ID to the select list
@@ -218,7 +218,7 @@ PhysicalOperator &LogicalCreateRTreeIndex::CreatePlan(ClientContext &context, Ph
 	auto &expr = op.unbound_expressions[0];
 
 	// Validate that we have the right type of expression (float array)
-	if (expr->return_type != LogicalType::GEOMETRY()) {
+	if (expr->GetReturnType() != LogicalType::GEOMETRY()) {
 		throw BinderException("RTree indexes can only be created over GEOMETRY columns.");
 	}
 
@@ -244,7 +244,7 @@ PhysicalOperator &LogicalCreateRTreeIndex::CreatePlan(ClientContext &context, Ph
 
 	// Add the geometry expression to the select list
 	auto geom_expr = op.expressions[0]->Copy();
-	new_column_types.push_back(geom_expr->return_type);
+	new_column_types.push_back(geom_expr->GetReturnType());
 	select_list.push_back(std::move(geom_expr));
 
 	// Add the row ID to the select list

--- a/src/spatial/index/rtree/rtree_index_create_logical.cpp
+++ b/src/spatial/index/rtree/rtree_index_create_logical.cpp
@@ -57,8 +57,7 @@ static PhysicalOperator &CreateNullFilter(PhysicalPlanGenerator &generator, cons
 	auto is_empty_func = is_empty_entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
 	vector<unique_ptr<Expression>> is_empty_args;
 	is_empty_args.push_back(std::move(bound_ref));
-	auto is_empty_expr = make_uniq_base<Expression, BoundFunctionExpression>(LogicalType::BOOLEAN, is_empty_func,
-	                                                                         std::move(is_empty_args), nullptr);
+	auto is_empty_expr = is_empty_func.Bind(context, std::move(is_empty_args));
 
 	auto is_not_empty_expr = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT, LogicalType::BOOLEAN);
 	is_not_empty_expr->children.push_back(std::move(is_empty_expr));
@@ -79,14 +78,13 @@ static PhysicalOperator &CreateBoundingBoxProjection(PhysicalPlanGenerator &plan
 	auto &bbox_func_entry =
 	    catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, DEFAULT_SCHEMA, "ST_Extent_Approx")
 	        .Cast<ScalarFunctionCatalogEntry>();
-	auto bbox_func = bbox_func_entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
+	const auto &bbox_func = bbox_func_entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
 
 	auto geom_ref_expr = make_uniq_base<Expression, BoundReferenceExpression>(LogicalType::GEOMETRY(), 0);
 	vector<unique_ptr<Expression>> bbox_args;
 	bbox_args.push_back(std::move(geom_ref_expr));
 
-	auto bbox_expr = make_uniq_base<Expression, BoundFunctionExpression>(GeoTypes::BOX_2DF(), bbox_func,
-	                                                                     std::move(bbox_args), nullptr);
+	auto bbox_expr = bbox_func.Bind(context, std::move(bbox_args));
 
 	// Also project the rowid column
 	auto rowid_expr = make_uniq_base<Expression, BoundReferenceExpression>(LogicalType::ROW_TYPE, 1);
@@ -106,25 +104,24 @@ static PhysicalOperator &CreateOrderByMinX(PhysicalPlanGenerator &planner, const
 	auto &centroid_func_entry =
 	    catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, DEFAULT_SCHEMA, "st_centroid")
 	        .Cast<ScalarFunctionCatalogEntry>();
-	auto centroid_func = centroid_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::BOX_2DF()});
+	const auto &centroid_func = centroid_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::BOX_2DF()});
 	vector<unique_ptr<Expression>> centroid_func_args;
 
 	// Reference the geometry column
 	auto geom_ref_expr = make_uniq_base<Expression, BoundReferenceExpression>(GeoTypes::BOX_2DF(), 0);
 	centroid_func_args.push_back(make_uniq_base<Expression, BoundReferenceExpression>(GeoTypes::BOX_2DF(), 0));
-	auto centroid_expr = make_uniq_base<Expression, BoundFunctionExpression>(GeoTypes::POINT_2D(), centroid_func,
-	                                                                         std::move(centroid_func_args), nullptr);
+
+	auto centroid_expr = centroid_func.Bind(context, std::move(centroid_func_args));
 
 	// Get the xmin value function
 	auto &xmin_func_entry = catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, DEFAULT_SCHEMA, "st_xmin")
 	                            .Cast<ScalarFunctionCatalogEntry>();
-	auto xmin_func = xmin_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::POINT_2D()});
+	const auto &xmin_func = xmin_func_entry.functions.GetFunctionByArguments(context, {GeoTypes::POINT_2D()});
 	vector<unique_ptr<Expression>> xmin_func_args;
 
 	// Reference the centroid
 	xmin_func_args.push_back(std::move(centroid_expr));
-	auto xmin_expr = make_uniq_base<Expression, BoundFunctionExpression>(LogicalType::DOUBLE, xmin_func,
-	                                                                     std::move(xmin_func_args), nullptr);
+	auto xmin_expr = xmin_func.Bind(context, std::move(xmin_func_args));
 
 	vector<BoundOrderByNode> orders;
 	orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST, std::move(xmin_expr));

--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
@@ -97,15 +97,15 @@ public:
 		if (predicates.find(function.name) == predicates.end()) {
 			return false;
 		}
-		if (function.arguments.size() < 2) {
+		if (function.GetArguments().size() < 2) {
 			// We can only optimize if there are two children
 			return false;
 		}
-		if (function.arguments[0] != LogicalType::GEOMETRY()) {
+		if (function.GetArguments()[0] != LogicalType::GEOMETRY()) {
 			// We can only optimize if the first child is a GEOMETRY
 			return false;
 		}
-		if (function.arguments[1] != LogicalType::GEOMETRY()) {
+		if (function.GetArguments()[1] != LogicalType::GEOMETRY()) {
 			// We can only optimize if the second child is a GEOMETRY
 			return false;
 		}

--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
@@ -40,7 +40,7 @@ public:
 	}
 
 	static void RewriteIndexExpression(Index &index, LogicalGet &get, Expression &expr, bool &rewrite_possible) {
-		if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
+		if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
 			auto &bound_colref = expr.Cast<BoundColumnRefExpression>();
 			// bound column ref: rewrite to fit in the current set of bound column ids
 			bound_colref.binding.table_index = get.table_index;
@@ -63,7 +63,7 @@ public:
 
 	static void RewriteIndexExpressionForFilter(Index &index, LogicalGet &get, unique_ptr<Expression> &expr,
 	                                            const ColumnIndex &filter_idx, bool &rewrite_possible) {
-		if (expr->type == ExpressionType::BOUND_COLUMN_REF) {
+		if (expr->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
 			auto &bound_colref = expr->Cast<BoundColumnRefExpression>();
 
 			auto &indexed_columns = index.GetColumnIds();
@@ -84,7 +84,7 @@ public:
 			}
 
 			// this column matches the index column - turn it into a BoundReference
-			expr = make_uniq<BoundReferenceExpression>(bound_colref.return_type, 0ULL);
+			expr = make_uniq<BoundReferenceExpression>(bound_colref.GetReturnType(), 0ULL);
 			return;
 		}
 		ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {

--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
@@ -92,9 +92,9 @@ public:
 		});
 	}
 
-	static bool IsSpatialPredicate(const ScalarFunction &function, const unordered_set<string> &predicates) {
+	static bool IsSpatialPredicate(const BoundScalarFunction &function, const unordered_set<string> &predicates) {
 
-		if (predicates.find(function.name) == predicates.end()) {
+		if (predicates.find(function.GetName()) == predicates.end()) {
 			return false;
 		}
 		if (function.GetArguments().size() < 2) {
@@ -121,13 +121,12 @@ public:
 		// make a new box expression
 		auto &catalog = Catalog::GetSystemCatalog(context);
 		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_Extent_Approx");
-		auto func = entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
+		const auto &func = entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
 
 		vector<unique_ptr<Expression>> children;
 		children.push_back(expr.Copy());
 
-		const auto bbox_expr =
-		    make_uniq<BoundFunctionExpression>(GeoTypes::BOX_2DF(), func, std::move(children), nullptr);
+		const auto bbox_expr = func.Bind(context, std::move(children));
 
 		Value result;
 		if (!ExpressionExecutor::TryEvaluateScalar(context, *bbox_expr, result)) {

--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
@@ -109,7 +109,7 @@ public:
 			// We can only optimize if the second child is a GEOMETRY
 			return false;
 		}
-		if (function.return_type != LogicalType::BOOLEAN) {
+		if (function.GetReturnType() != LogicalType::BOOLEAN) {
 			// We can only optimize if the return type is a BOOLEAN
 			return false;
 		}

--- a/src/spatial/index/rtree/rtree_index_pragmas.cpp
+++ b/src/spatial/index/rtree/rtree_index_pragmas.cpp
@@ -103,7 +103,7 @@ static void RTreeIndexInfoExecute(ClientContext &context, TableFunctionInput &da
 
 		row++;
 	}
-	output.SetCardinality(row);
+	output.SetChildCardinality(row);
 }
 
 static optional_ptr<RTreeIndex> TryGetIndex(ClientContext &context, const string &index_name) {
@@ -233,7 +233,11 @@ static void RTreeIndexDumpExecute(ClientContext &context, TableFunctionInput &da
 		return RTreeScanResult::CONTINUE;
 	});
 
-	output.SetCardinality(output_idx);
+	FlatVector::SetSize(bounds_vectors[0], count_t(output_idx));
+	FlatVector::SetSize(bounds_vectors[1], count_t(output_idx));
+	FlatVector::SetSize(bounds_vectors[2], count_t(output_idx));
+	FlatVector::SetSize(bounds_vectors[3], count_t(output_idx));
+	output.SetChildCardinality(output_idx);
 }
 
 //-------------------------------------------------------------------------

--- a/src/spatial/index/rtree/rtree_index_pragmas.cpp
+++ b/src/spatial/index/rtree/rtree_index_pragmas.cpp
@@ -204,13 +204,13 @@ static void RTreeIndexDumpExecute(ClientContext &context, TableFunctionInput &da
 
 	idx_t output_idx = 0;
 
-	const auto level_data = FlatVector::GetData<int32_t>(output.data[0]);
+	auto level_data = FlatVector::GetDataMutable<int32_t>(output.data[0]);
 	auto &bounds_vectors = StructVector::GetEntries(output.data[1]);
-	const auto xmin_data = FlatVector::GetData<float>(bounds_vectors[0]);
-	const auto ymin_data = FlatVector::GetData<float>(bounds_vectors[1]);
-	const auto xmax_data = FlatVector::GetData<float>(bounds_vectors[2]);
-	const auto ymax_data = FlatVector::GetData<float>(bounds_vectors[3]);
-	const auto rowid_data = FlatVector::GetData<row_t>(output.data[2]);
+	auto xmin_data = FlatVector::GetDataMutable<float>(bounds_vectors[0]);
+	auto ymin_data = FlatVector::GetDataMutable<float>(bounds_vectors[1]);
+	auto xmax_data = FlatVector::GetDataMutable<float>(bounds_vectors[2]);
+	auto ymax_data = FlatVector::GetDataMutable<float>(bounds_vectors[3]);
+	auto rowid_data = FlatVector::GetDataMutable<row_t>(output.data[2]);
 
 	const auto &tree = *state.index.tree;
 

--- a/src/spatial/index/rtree/rtree_index_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_scan.cpp
@@ -261,6 +261,7 @@ TableFunction RTreeIndexScanFunction::GetFunction() {
 	func.get_bind_info = RTreeIndexScanBindInfo;
 	func.serialize = RTreeScanSerialize;
 	func.deserialize = RTreeScanDeserialize;
+	func.parallelism = TableFunctionParallelism::SEQUENTIAL;
 
 	return func;
 }

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -1180,6 +1180,7 @@ void Register(ExtensionLoader &loader) {
 	read_func.named_parameters["layer"] = LogicalType::VARCHAR;
 	read_func.named_parameters["max_batch_size"] = LogicalType::INTEGER;
 	read_func.named_parameters["keep_wkb"] = LogicalType::BOOLEAN;
+	read_func.parallelism = TableFunctionParallelism::SEQUENTIAL;
 
 	loader.RegisterFunction(read_func);
 

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -739,7 +739,7 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data, 
 		if (expr->GetExpressionType() != ExpressionType::BOUND_FUNCTION) {
 			continue;
 		}
-		if (expr->return_type != LogicalType::BOOLEAN) {
+		if (expr->GetReturnType() != LogicalType::BOOLEAN) {
 			continue;
 		}
 		const auto &func = expr->Cast<BoundFunctionExpression>();
@@ -747,8 +747,8 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data, 
 			continue;
 		}
 
-		if (func.children[0]->return_type.id() != LogicalTypeId::GEOMETRY ||
-		    func.children[1]->return_type.id() != LogicalTypeId::GEOMETRY) {
+		if (func.children[0]->GetReturnType().id() != LogicalTypeId::GEOMETRY ||
+		    func.children[1]->GetReturnType().id() != LogicalTypeId::GEOMETRY) {
 			continue;
 		}
 
@@ -821,7 +821,7 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data, 
 			// Constant is NULL
 			continue;
 		}
-		if (geometry_expr->return_type.id() != LogicalTypeId::GEOMETRY) {
+		if (geometry_expr->GetReturnType().id() != LogicalTypeId::GEOMETRY) {
 			// Not the geometry column
 			continue;
 		}

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -992,6 +992,7 @@ void Scan(ClientContext &context, TableFunctionInput &input, DataChunk &output) 
 		default:
 			throw NotImplementedException("ArrowArrayPhysicalType not recognized");
 		}
+		FlatVector::SetSize(vec, count_t(arrow_array.length));
 	}
 
 	state.features_read += arrow_array.length;
@@ -1691,7 +1692,7 @@ void Scan(ClientContext &context, TableFunctionInput &input, DataChunk &output) 
 		output.data[5].SetValue(count, help_topic_value);
 		count++;
 	}
-	output.SetCardinality(count);
+	output.SetChildCardinality(count);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -1908,7 +1909,7 @@ void Scan(ClientContext &context, TableFunctionInput &input, DataChunk &output) 
 		output_idx++;
 	}
 
-	output.SetCardinality(output_idx);
+	output.SetChildCardinality(output_idx);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -759,7 +759,7 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data, 
 
 		auto found = false;
 		for (const auto &name : geometry_predicates) {
-			if (StringUtil::CIEquals(func.function.name.c_str(), name)) {
+			if (StringUtil::CIEquals(func.function.GetName().c_str(), name)) {
 				found = true;
 				break;
 			}
@@ -841,7 +841,7 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data, 
 		// We can __ONLY__ do this if the filter predicate is "&&" or "st_intersects_extent"
 		// as other predicates may require exact geometry evaluation, the filter cannot be fully removed
 		for (auto &name : {"&&", "ST_Intersects_Extent"}) {
-			if (StringUtil::CIEquals(func.function.name.c_str(), name)) {
+			if (StringUtil::CIEquals(func.function.GetName().c_str(), name)) {
 				geom_filter_idx = expr_idx;
 				break;
 			}

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -478,12 +478,11 @@ struct ST_Boundary {
 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
 
-		UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
-		    args.data[0], result, args.size(), [&](const string_t &geom_blob, ValidityMask &mask, idx_t row_idx) {
+		UnaryExecutor::Execute<string_t, string_t>(
+		    args.data[0], result, args.size(), [&](const string_t &geom_blob) -> optional<string_t> {
 			    const auto geom = lstate.Deserialize(geom_blob);
 			    if (geom.type() == GEOS_GEOMETRYCOLLECTION) {
-				    mask.SetInvalid(row_idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 			    const auto boundary = geom.get_boundary();
 
@@ -872,9 +871,9 @@ struct ST_CoverageInvalidEdges {
 		// Collection to hold the working set of geometries
 		GeosCollection collection(lstate.GetContext());
 
-		BinaryExecutor::ExecuteWithNulls<list_entry_t, double, string_t>(
+		BinaryExecutor::Execute<list_entry_t, double, string_t>(
 		    list_vec, args.data[1], result, args.size(),
-		    [&](const list_entry_t &list, double tolerance, ValidityMask &mask, idx_t row_idx) {
+		    [&](const list_entry_t &list, double tolerance) -> optional<string_t> {
 			    // Reset the collection
 			    collection.clear();
 			    collection.reserve(list.length);
@@ -901,8 +900,7 @@ struct ST_CoverageInvalidEdges {
 			    const auto invalid = geometry_col.get_coverage_invalid_edges(tolerance);
 
 			    if (invalid.is_empty()) {
-				    mask.SetInvalid(row_idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    return lstate.Serialize(result, invalid);
@@ -2143,15 +2141,14 @@ struct ST_ShortestLine {
 struct ST_ClosestPoint {
 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
-		BinaryExecutor::ExecuteWithNulls<string_t, string_t, string_t>(
+		BinaryExecutor::Execute<string_t, string_t, string_t>(
 		    args.data[0], args.data[1], result, args.size(),
-		    [&](const string_t &lhs_blob, const string_t &rhs_blob, ValidityMask &mask, idx_t row_idx) {
+		    [&](const string_t &lhs_blob, const string_t &rhs_blob) -> optional<string_t> {
 			    const auto lhs = lstate.Deserialize(lhs_blob);
 			    const auto rhs = lstate.Deserialize(rhs_blob);
 			    const auto line = lhs.get_shortest_line(rhs);
 			    if (line.is_empty()) {
-				    mask.SetInvalid(row_idx);
-				    return string_t();
+				    return nullopt;
 			    }
 			    const auto point = line.get_point_n(0);
 			    return lstate.Serialize(result, point);

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -4,7 +4,7 @@
 #include "spatial/spatial_types.hpp"
 #include "spatial/util/function_builder.hpp"
 
-#include "duckdb/common/vector_operations/senary_executor.hpp"
+#include "duckdb/common/vector_operations/variadic_executor.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -550,7 +550,7 @@ struct ST_Buffer {
 	static void ExecuteWithStyle(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
 
-		SenaryExecutor::Execute<string_t, double, int32_t, string_t, string_t, double, string_t>(
+		VariadicExecutor::Execute<string_t, string_t, double, int32_t, string_t, string_t, double>(
 		    args, result,
 		    [&](const string_t &blob, double radius, int32_t segments, const string_t &cap_style_str,
 		        const string_t &join_style_str, double mitre_limit) {

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/aggregate_function.hpp"
 #include "spatial/geometry/geometry_serialization.hpp"
 #include "spatial/geometry/sgl.hpp"
 
@@ -2518,7 +2519,7 @@ struct ST_Union_Agg {
 		vector<GEOSGeometry *> geoms;
 	};
 
-	static idx_t StateSize(const AggregateFunction &) {
+	static idx_t StateSize(const BoundAggregateFunction &) {
 		return sizeof(State);
 	}
 
@@ -2543,7 +2544,7 @@ struct ST_Union_Agg {
 		return GeosSerde::Deserialize(context, arena, ptr, size);
 	}
 
-	static void Initialize(const AggregateFunction &, data_ptr_t state_mem) {
+	static void Initialize(const BoundAggregateFunction &, data_ptr_t state_mem) {
 		const auto state_ptr = new (state_mem) State();
 		auto &state = *state_ptr;
 		state.context = GEOS_init_r();
@@ -2742,7 +2743,7 @@ struct GEOSCoverageAggFunction {
 		return GeosSerde::Deserialize(context, arena, ptr, size);
 	}
 
-	static void Initialize(const AggregateFunction &, data_ptr_t state_mem) {
+	static void Initialize(const BoundAggregateFunction &, data_ptr_t state_mem) {
 		const auto state_ptr = new (state_mem) State();
 		auto &state = *state_ptr;
 		state.context = GEOS_init_r();
@@ -2809,7 +2810,7 @@ struct GEOSCoverageAggFunction {
 		}
 	}
 
-	static idx_t StateSize(const AggregateFunction &) {
+	static idx_t StateSize(const BoundAggregateFunction &) {
 		return sizeof(State);
 	}
 
@@ -2965,7 +2966,7 @@ struct ST_CoverageSimplify_Agg : GEOSCoverageAggFunction {
 			func.SetDescription("Simplifies a set of geometries while maintaining coverage");
 
 			// TODO: this is a hack
-			agg.GetArguments().push_back(LogicalType::BOOLEAN);
+			agg.GetSignature().AddParameter(LogicalType::BOOLEAN);
 			func.SetFunction(agg);
 			func.CanThrowErrors();
 
@@ -3130,7 +3131,7 @@ struct ST_CoverageInvalidEdges_Agg : GEOSCoverageAggFunction {
 			func.CanThrowErrors();
 
 			// TODO: this is a hack
-			agg.GetArguments().push_back(LogicalType::DOUBLE);
+			agg.GetSignature().AddParameter(LogicalType::DOUBLE);
 			func.SetFunction(agg);
 			func.CanThrowErrors();
 

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -2466,7 +2466,7 @@ struct ST_MemUnion_Agg : GeosUnaryAggFunction {
 		auto agg = AggregateFunction::UnaryAggregateDestructor<GeosUnaryAggState, string_t, string_t, ST_MemUnion_Agg>(
 		    LogicalType::GEOMETRY(), LogicalType::GEOMETRY());
 
-		agg.bind = GeoTypes::PropagateCRS;
+		agg.SetBindCallback(GeoTypes::PropagateCRS);
 
 		FunctionBuilder::RegisterAggregate(loader, "ST_MemUnion_Agg", [&](AggregateFunctionBuilder &func) {
 			func.SetFunction(agg);
@@ -2494,7 +2494,7 @@ struct ST_Intersection_Agg : GeosUnaryAggFunction {
 		    AggregateFunction::UnaryAggregateDestructor<GeosUnaryAggState, string_t, string_t, ST_Intersection_Agg>(
 		        LogicalType::GEOMETRY(), LogicalType::GEOMETRY());
 
-		agg.bind = GeoTypes::PropagateCRS;
+		agg.SetBindCallback(GeoTypes::PropagateCRS);
 		FunctionBuilder::RegisterAggregate(loader, "ST_Intersection_Agg", [&](AggregateFunctionBuilder &func) {
 			func.SetFunction(agg);
 			func.CanThrowErrors();

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -317,7 +317,7 @@ struct ST_AsMVTGeom {
 		const auto maxx_data = UnifiedVectorFormat::GetData<double>(maxx_format);
 		const auto maxy_data = UnifiedVectorFormat::GetData<double>(maxy_format);
 
-		const auto res_data = FlatVector::GetData<string_t>(result);
+		const auto res_data = FlatVector::GetDataMutable<string_t>(result);
 
 		for (idx_t out_idx = 0; out_idx < args.size(); out_idx++) {
 			const auto geom_idx = geom_format.sel->get_index(out_idx);
@@ -2582,7 +2582,7 @@ struct ST_Union_Agg {
 		state_vec.ToUnifiedFormat(count, state_format);
 
 		const auto state_ptr = UnifiedVectorFormat::GetData<State *>(state_format);
-		const auto combined_ptr = FlatVector::GetData<State *>(combined);
+		const auto combined_ptr = FlatVector::GetDataMutable<State *>(combined);
 
 		for (idx_t raw_idx = 0; raw_idx < count; raw_idx++) {
 			const auto state_idx = state_format.sel->get_index(raw_idx);
@@ -2647,7 +2647,7 @@ struct ST_Union_Agg {
 				const auto result_union = GEOSUnaryUnion_r(state.context, collection);
 
 				// Serialize the result
-				const auto result_ptr = FlatVector::GetData<string_t>(result);
+				const auto result_ptr = FlatVector::GetDataMutable<string_t>(result);
 				result_ptr[out_idx] = Serialize(state.context, result, result_union);
 
 				// Destroy the unioned geometry
@@ -2753,7 +2753,7 @@ struct GEOSCoverageAggFunction {
 		state_vec.ToUnifiedFormat(count, state_format);
 
 		const auto state_ptr = UnifiedVectorFormat::GetData<State *>(state_format);
-		const auto combined_ptr = FlatVector::GetData<State *>(combined);
+		const auto combined_ptr = FlatVector::GetDataMutable<State *>(combined);
 
 		for (idx_t raw_idx = 0; raw_idx < count; raw_idx++) {
 			const auto state_idx = state_format.sel->get_index(raw_idx);
@@ -2820,7 +2820,7 @@ struct GEOSCoverageAggFunction {
 
 		const auto state_ptr = UnifiedVectorFormat::GetData<State *>(state_format);
 
-		auto &mask = FlatVector::Validity(result);
+		auto &mask = FlatVector::ValidityMutable(result);
 
 		for (idx_t raw_idx = 0; raw_idx < count; raw_idx++) {
 			auto &state = *state_ptr[state_format.sel->get_index(raw_idx)];
@@ -2943,7 +2943,7 @@ struct ST_CoverageSimplify_Agg : GEOSCoverageAggFunction {
 		    GEOSCoverageSimplifyVW_r(state.context, collection, state.tolerance, !state.simplify_boundary);
 
 		// Serialize the result
-		const auto result_ptr = FlatVector::GetData<string_t>(result);
+		const auto result_ptr = FlatVector::GetDataMutable<string_t>(result);
 		result_ptr[out_idx] = Serialize(state.context, result, simplified);
 		GEOSGeom_destroy_r(state.context, simplified);
 	}
@@ -3017,7 +3017,7 @@ struct ST_CoverageUnion_Agg : GEOSCoverageAggFunction {
 		const auto coverage = GEOSCoverageUnion_r(state.context, collection);
 
 		// Serialize the result
-		const auto result_ptr = FlatVector::GetData<string_t>(result);
+		const auto result_ptr = FlatVector::GetDataMutable<string_t>(result);
 		result_ptr[out_idx] = Serialize(state.context, result, coverage);
 		GEOSGeom_destroy_r(state.context, coverage);
 	}
@@ -3108,7 +3108,7 @@ struct ST_CoverageInvalidEdges_Agg : GEOSCoverageAggFunction {
 			return;
 		}
 		// Serialize the result
-		const auto result_ptr = FlatVector::GetData<string_t>(result);
+		const auto result_ptr = FlatVector::GetDataMutable<string_t>(result);
 		result_ptr[out_idx] = Serialize(state.context, result, edges);
 		GEOSGeom_destroy_r(state.context, edges);
 	}

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -229,8 +229,11 @@ struct ST_AsMVTGeom {
 		}
 	};
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto &arguments = input.GetArguments();
+		auto &bound_function = input.GetBoundFunction();
+		auto &context = input.GetClientContext();
+
 		auto result = make_uniq<BindData>();
 
 		// Extract parameters
@@ -846,8 +849,9 @@ struct ST_ConvexHull {
 
 struct ST_CoverageInvalidEdges {
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+
+		auto &arguments = input.GetArguments();
 
 		// Set the default value for the tolerance parameter
 		if (arguments.size() == 1) {
@@ -941,8 +945,9 @@ struct ST_CoverageInvalidEdges {
 
 struct ST_CoverageSimplify {
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto &arguments = input.GetArguments();
+
 		// Set the default value for the simplify_boundary parameter
 		if (arguments.size() == 2) {
 			arguments.push_back(make_uniq_base<Expression, BoundConstantExpression>(Value::BOOLEAN(true)));
@@ -2876,8 +2881,10 @@ struct GEOSCoverageAggFunction {
 
 struct ST_CoverageSimplify_Agg : GEOSCoverageAggFunction {
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &arguments = input.GetArguments();
+		auto &function = input.GetBoundFunction();
+
 		if (arguments.size() == 2) {
 			arguments.push_back(make_uniq_base<Expression, BoundConstantExpression>(Value::BOOLEAN(true)));
 			function.arguments.push_back(LogicalType::BOOLEAN);
@@ -3045,8 +3052,10 @@ struct ST_CoverageUnion_Agg : GEOSCoverageAggFunction {
 
 struct ST_CoverageInvalidEdges_Agg : GEOSCoverageAggFunction {
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &arguments = input.GetArguments();
+		auto &function = input.GetBoundFunction();
+
 		if (arguments.size() == 1) {
 			arguments.push_back(make_uniq_base<Expression, BoundConstantExpression>(Value::DOUBLE(0.0)));
 			function.arguments.push_back(LogicalType::DOUBLE);

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -524,7 +524,7 @@ struct ST_Buffer {
 		auto &lstate = LocalState::ResetAndGet(state);
 
 		TernaryExecutor::Execute<string_t, double, int32_t, string_t>(
-		    args.data[0], args.data[1], args.data[2], result, args.size(),
+		    args.data[0], args.data[1], args.data[2], result,
 		    [&](const string_t &blob, double radius, int32_t segments) {
 			    const auto geom = lstate.Deserialize(blob);
 			    const auto buffer = geom.get_buffer(radius, segments);
@@ -781,7 +781,7 @@ struct ST_ConcaveHull {
 		auto &lstate = LocalState::ResetAndGet(state);
 
 		TernaryExecutor::Execute<string_t, double, bool, string_t>(
-		    args.data[0], args.data[1], args.data[2], result, args.size(),
+		    args.data[0], args.data[1], args.data[2], result,
 		    [&](const string_t &geom_blob, const double ratio, const bool allowHoles) {
 			    const auto geom = lstate.Deserialize(geom_blob);
 			    const auto hull = geom.get_concave_hull(ratio, allowHoles);
@@ -963,7 +963,7 @@ struct ST_CoverageSimplify {
 		GeosCollection collection(lstate.GetContext());
 
 		TernaryExecutor::Execute<list_entry_t, double, bool, string_t>(
-		    list_vec, args.data[1], args.data[2], result, args.size(),
+		    list_vec, args.data[1], args.data[2], result,
 		    [&](const list_entry_t &list, double tolerance, bool simplify_boundary) {
 			    // Reset the collection
 			    collection.clear();
@@ -1325,7 +1325,7 @@ struct ST_DistanceWithin {
 		} else {
 			// Both are non-const, just execute normally
 			TernaryExecutor::Execute<string_t, string_t, double, bool>(
-			    lhs_vec, rhs_vec, arg_vec, result, args.size(),
+			    lhs_vec, rhs_vec, arg_vec, result,
 			    [&](const string_t &lhs_blob, const string_t &rhs_blob, double distance) {
 				    const auto lhs = lstate.Deserialize(lhs_blob);
 				    const auto rhs = lstate.Deserialize(rhs_blob);

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -2887,7 +2887,7 @@ struct ST_CoverageSimplify_Agg : GEOSCoverageAggFunction {
 
 		if (arguments.size() == 2) {
 			arguments.push_back(make_uniq_base<Expression, BoundConstantExpression>(Value::BOOLEAN(true)));
-			function.arguments.push_back(LogicalType::BOOLEAN);
+			function.GetArguments().push_back(LogicalType::BOOLEAN);
 		}
 		return nullptr;
 	}
@@ -2968,7 +2968,7 @@ struct ST_CoverageSimplify_Agg : GEOSCoverageAggFunction {
 			func.SetDescription("Simplifies a set of geometries while maintaining coverage");
 
 			// TODO: this is a hack
-			agg.arguments.push_back(LogicalType::BOOLEAN);
+			agg.GetArguments().push_back(LogicalType::BOOLEAN);
 			func.SetFunction(agg);
 			func.CanThrowErrors();
 
@@ -3058,7 +3058,7 @@ struct ST_CoverageInvalidEdges_Agg : GEOSCoverageAggFunction {
 
 		if (arguments.size() == 1) {
 			arguments.push_back(make_uniq_base<Expression, BoundConstantExpression>(Value::DOUBLE(0.0)));
-			function.arguments.push_back(LogicalType::DOUBLE);
+			function.GetArguments().push_back(LogicalType::DOUBLE);
 		}
 		return nullptr;
 	}
@@ -3133,7 +3133,7 @@ struct ST_CoverageInvalidEdges_Agg : GEOSCoverageAggFunction {
 			func.CanThrowErrors();
 
 			// TODO: this is a hack
-			agg.arguments.push_back(LogicalType::DOUBLE);
+			agg.GetArguments().push_back(LogicalType::DOUBLE);
 			func.SetFunction(agg);
 			func.CanThrowErrors();
 

--- a/src/spatial/modules/main/spatial_functions_aggregate.cpp
+++ b/src/spatial/modules/main/spatial_functions_aggregate.cpp
@@ -143,7 +143,7 @@ void RegisterSpatialAggregateFunctions(ExtensionLoader &loader) {
 	auto agg = AggregateFunction::UnaryAggregate<ExtentAggState, string_t, string_t, ExtentAggFunction>(
 	    LogicalType::GEOMETRY(), LogicalType::GEOMETRY());
 
-	agg.bind = GeoTypes::PropagateCRS;
+	agg.SetBindCallback(GeoTypes::PropagateCRS);
 
 	FunctionBuilder::RegisterAggregate(loader, "ST_Extent_Agg", [&](AggregateFunctionBuilder &func) {
 		func.SetFunction(agg);

--- a/src/spatial/modules/main/spatial_functions_cast.cpp
+++ b/src/spatial/modules/main/spatial_functions_cast.cpp
@@ -91,8 +91,8 @@ struct GeometryCasts {
 
 		bool success = true;
 
-		UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
-		    source, result, count, [&](const string_t &wkb, ValidityMask &mask, idx_t row_idx) {
+		UnaryExecutor::Execute<string_t, string_t>(
+		    source, result, count, [&](const string_t &wkb) -> optional<string_t> {
 			    const auto wkb_ptr = wkb.GetDataUnsafe();
 			    const auto wkb_len = wkb.GetSize();
 
@@ -105,8 +105,7 @@ struct GeometryCasts {
 					    success = false;
 					    HandleCastError::AssignError(error, params.error_message);
 				    }
-				    mask.SetInvalid(row_idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    return lstate.Serialize(result, geom);
@@ -972,7 +971,7 @@ void CoreVectorOperations::LineString2DToVarchar(Vector &source, Vector &result,
 	auto x_data = FlatVector::GetData<double>(children[0]);
 	auto y_data = FlatVector::GetData<double>(children[1]);
 
-	UnaryExecutor::Execute<list_entry_t, string_t>(source, result, count, [&](list_entry_t &line) {
+	UnaryExecutor::Execute<list_entry_t, string_t>(source, result, count, [&](const list_entry_t &line) {
 		auto offset = line.offset;
 		auto length = line.length;
 
@@ -1002,7 +1001,7 @@ void CoreVectorOperations::LineString3DToVarchar(Vector &source, Vector &result,
 	auto y_data = FlatVector::GetData<double>(children[1]);
 	auto z_data = FlatVector::GetData<double>(children[2]);
 
-	UnaryExecutor::Execute<list_entry_t, string_t>(source, result, count, [&](list_entry_t &line) {
+	UnaryExecutor::Execute<list_entry_t, string_t>(source, result, count, [&](const list_entry_t &line) {
 		auto offset = line.offset;
 		auto length = line.length;
 

--- a/src/spatial/modules/main/spatial_functions_cast.cpp
+++ b/src/spatial/modules/main/spatial_functions_cast.cpp
@@ -456,11 +456,11 @@ struct LinestringCasts {
 			auto &coord_vec = ListVector::GetEntry(result);
 			auto &coord_vec_children = StructVector::GetEntries(coord_vec);
 
-			const auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
-			const auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+			auto x_data = FlatVector::GetDataMutable<double>(coord_vec_children[0]);
+			auto y_data = FlatVector::GetDataMutable<double>(coord_vec_children[1]);
 
 			if (HAS_Z) {
-				const auto z_data = FlatVector::GetData<double>(coord_vec_children[2]);
+				auto z_data = FlatVector::GetDataMutable<double>(coord_vec_children[2]);
 				for (idx_t i = 0; i < line_size; i++) {
 					const auto vertex = line.get_vertex_xyzm(i);
 					x_data[entry.offset + i] = vertex.x;
@@ -516,8 +516,8 @@ struct LinestringCasts {
 			auto &coord_dst = ListVector::GetEntry(result);
 			auto &coord_dst_children = StructVector::GetEntries(coord_dst);
 
-			const auto x_dst = FlatVector::GetData<double>(coord_dst_children[0]);
-			const auto y_dst = FlatVector::GetData<double>(coord_dst_children[1]);
+			auto x_dst = FlatVector::GetDataMutable<double>(coord_dst_children[0]);
+			auto y_dst = FlatVector::GetDataMutable<double>(coord_dst_children[1]);
 
 			for (idx_t i = 0; i < line.length; i++) {
 				x_dst[entry.offset + i] = x_src[line.offset + i];
@@ -689,13 +689,13 @@ struct PolygonCasts {
 					const auto ring_entries = ListVector::GetData(ring_vec);
 					auto &coord_vec = ListVector::GetEntry(ring_vec);
 					auto &coord_vec_children = StructVector::GetEntries(coord_vec);
-					const auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
-					const auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+					auto x_data = FlatVector::GetDataMutable<double>(coord_vec_children[0]);
+					auto y_data = FlatVector::GetDataMutable<double>(coord_vec_children[1]);
 
 					ring_entries[total_rings + ring_idx] = ring_entry;
 
 					if (HAS_Z) {
-						const auto z_data = FlatVector::GetData<double>(coord_vec_children[2]);
+						auto z_data = FlatVector::GetDataMutable<double>(coord_vec_children[2]);
 						for (idx_t j = 0; j < ring_size; j++) {
 							const auto vertext = head->get_vertex_xyzm(j);
 							x_data[ring_entry.offset + j] = vertext.x;
@@ -770,8 +770,8 @@ struct PolygonCasts {
 				const auto ring_entries_dst = ListVector::GetData(ring_dst);
 				auto &coord_dst = ListVector::GetEntry(ring_dst);
 				auto &coord_dst_children = StructVector::GetEntries(coord_dst);
-				const auto x_dst = FlatVector::GetData<double>(coord_dst_children[0]);
-				const auto y_dst = FlatVector::GetData<double>(coord_dst_children[1]);
+				auto x_dst = FlatVector::GetDataMutable<double>(coord_dst_children[0]);
+				auto y_dst = FlatVector::GetDataMutable<double>(coord_dst_children[1]);
 
 				ring_entries_dst[total_rings + i] = ring_entry_dst;
 

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -5457,6 +5457,7 @@ struct ST_LocateAlong {
 		if (arguments.size() == 2) {
 			// Push back offset constant
 			arguments.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(0.0)));
+			input.GetBoundFunction().GetArguments().push_back(LogicalType::DOUBLE);
 		}
 		return nullptr; // No additional data needed
 	}
@@ -5558,6 +5559,7 @@ struct ST_LocateBetween {
 		if (arguments.size() == 3) {
 			// Push back offset constant
 			arguments.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(0.0)));
+			input.GetBoundFunction().GetArguments().push_back(LogicalType::DOUBLE);
 		}
 		return nullptr; // No additional data needed
 	}

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -442,8 +442,8 @@ struct ST_Area {
 		auto ring_entries = ListVector::GetData(ring_vec);
 		auto &coord_vec = ListVector::GetEntry(ring_vec);
 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
-		auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
-		auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+		auto x_data = FlatVector::GetDataMutable<double>(coord_vec_children[0]);
+		auto y_data = FlatVector::GetDataMutable<double>(coord_vec_children[1]);
 
 		UnaryExecutor::Execute<list_entry_t, double>(input, result, count, [&](list_entry_t polygon) {
 			auto polygon_offset = polygon.offset;
@@ -1394,12 +1394,12 @@ struct ST_Centroid {
 		auto line_vertex_entries = ListVector::GetData(input);
 		auto &line_vertex_vec = ListVector::GetEntry(input);
 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
-		auto line_x_data = FlatVector::GetData<double>(line_vertex_vec_children[0]);
-		auto line_y_vec = FlatVector::GetData<double>(line_vertex_vec_children[1]);
+		auto line_x_data = FlatVector::GetDataMutable<double>(line_vertex_vec_children[0]);
+		auto line_y_vec = FlatVector::GetDataMutable<double>(line_vertex_vec_children[1]);
 
 		auto &point_vertex_children = StructVector::GetEntries(result);
-		auto point_x_data = FlatVector::GetData<double>(point_vertex_children[0]);
-		auto point_y_data = FlatVector::GetData<double>(point_vertex_children[1]);
+		auto point_x_data = FlatVector::GetDataMutable<double>(point_vertex_children[0]);
+		auto point_y_data = FlatVector::GetDataMutable<double>(point_vertex_children[1]);
 		for (idx_t out_row_idx = 0; out_row_idx < count; out_row_idx++) {
 
 			auto in_row_idx = format.sel->get_index(out_row_idx);
@@ -1453,12 +1453,12 @@ struct ST_Centroid {
 		auto ring_entries = ListVector::GetData(ring_vec);
 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
-		auto x_data = FlatVector::GetData<double>(vertex_vec_children[0]);
-		auto y_data = FlatVector::GetData<double>(vertex_vec_children[1]);
+		auto x_data = FlatVector::GetDataMutable<double>(vertex_vec_children[0]);
+		auto y_data = FlatVector::GetDataMutable<double>(vertex_vec_children[1]);
 
 		auto &centroid_children = StructVector::GetEntries(result);
-		auto centroid_x_data = FlatVector::GetData<double>(centroid_children[0]);
-		auto centroid_y_data = FlatVector::GetData<double>(centroid_children[1]);
+		auto centroid_x_data = FlatVector::GetDataMutable<double>(centroid_children[0]);
+		auto centroid_y_data = FlatVector::GetDataMutable<double>(centroid_children[1]);
 
 		for (idx_t in_row_idx = 0; in_row_idx < count; in_row_idx++) {
 			if (format.validity.RowIsValid(in_row_idx)) {
@@ -1535,14 +1535,14 @@ struct ST_Centroid {
 		UnifiedVectorFormat format;
 		input.ToUnifiedFormat(count, format);
 		auto &box_children = StructVector::GetEntries(input);
-		auto minx_data = FlatVector::GetData<T>(box_children[0]);
-		auto miny_data = FlatVector::GetData<T>(box_children[1]);
-		auto maxx_data = FlatVector::GetData<T>(box_children[2]);
-		auto maxy_data = FlatVector::GetData<T>(box_children[3]);
+		auto minx_data = FlatVector::GetDataMutable<T>(box_children[0]);
+		auto miny_data = FlatVector::GetDataMutable<T>(box_children[1]);
+		auto maxx_data = FlatVector::GetDataMutable<T>(box_children[2]);
+		auto maxy_data = FlatVector::GetDataMutable<T>(box_children[3]);
 
 		auto &centroid_children = StructVector::GetEntries(result);
-		auto centroid_x_data = FlatVector::GetData<double>(centroid_children[0]);
-		auto centroid_y_data = FlatVector::GetData<double>(centroid_children[1]);
+		auto centroid_x_data = FlatVector::GetDataMutable<double>(centroid_children[0]);
+		auto centroid_y_data = FlatVector::GetDataMutable<double>(centroid_children[1]);
 
 		for (idx_t out_row_idx = 0; out_row_idx < count; out_row_idx++) {
 			auto in_row_idx = format.sel->get_index(out_row_idx);
@@ -2012,8 +2012,8 @@ struct ST_Contains {
 
 		// Setup point vectors
 		auto &p_children = StructVector::GetEntries(in_point);
-		auto p_x_data = FlatVector::GetData<double>(p_children[0]);
-		auto p_y_data = FlatVector::GetData<double>(p_children[1]);
+		auto p_x_data = FlatVector::GetDataMutable<double>(p_children[0]);
+		auto p_y_data = FlatVector::GetDataMutable<double>(p_children[1]);
 
 		// Setup polygon vectors
 		auto polygon_entries = ListVector::GetData(in_polygon);
@@ -2021,10 +2021,10 @@ struct ST_Contains {
 		auto ring_entries = ListVector::GetData(ring_vec);
 		auto &coord_vec = ListVector::GetEntry(ring_vec);
 		auto &coord_children = StructVector::GetEntries(coord_vec);
-		auto x_data = FlatVector::GetData<double>(coord_children[0]);
-		auto y_data = FlatVector::GetData<double>(coord_children[1]);
+		auto x_data = FlatVector::GetDataMutable<double>(coord_children[0]);
+		auto y_data = FlatVector::GetDataMutable<double>(coord_children[1]);
 
-		auto result_data = FlatVector::GetData<bool>(result);
+		auto result_data = FlatVector::GetDataMutable<bool>(result);
 		for (idx_t polygon_idx = 0; polygon_idx < count; polygon_idx++) {
 			auto polygon = polygon_entries[polygon_idx];
 			auto polygon_offset = polygon.offset;
@@ -2272,18 +2272,16 @@ struct ST_Azimuth {
 		auto &left_entries = StructVector::GetEntries(left);
 		auto &right_entries = StructVector::GetEntries(right);
 
-		auto left_x = FlatVector::GetData<double>(left_entries[0]);
-		auto left_y = FlatVector::GetData<double>(left_entries[1]);
-		auto right_x = FlatVector::GetData<double>(right_entries[0]);
-		auto right_y = FlatVector::GetData<double>(right_entries[1]);
+		auto left_x = FlatVector::GetDataMutable<double>(left_entries[0]);
+		auto left_y = FlatVector::GetDataMutable<double>(left_entries[1]);
+		auto right_x = FlatVector::GetDataMutable<double>(right_entries[0]);
+		auto right_y = FlatVector::GetDataMutable<double>(right_entries[1]);
 
-		auto &result_mask = FlatVector::Validity(result);
-
-		auto out_data = FlatVector::GetData<double>(result);
+		auto out_data = FlatVector::GetDataMutable<double>(result);
 		for (idx_t i = 0; i < count; i++) {
 			// If the points are the same, return NULL
 			if (left_x[i] == right_x[i] && left_y[i] == right_y[i]) {
-				result_mask.SetInvalid(i);
+				FlatVector::SetNull(result, i, true);
 				continue;
 			}
 			out_data[i] = CalcAngle(left_x[i], left_y[i], right_x[i], right_y[i]);
@@ -2406,12 +2404,12 @@ struct ST_Distance {
 		auto &left_entries = StructVector::GetEntries(left);
 		auto &right_entries = StructVector::GetEntries(right);
 
-		auto left_x = FlatVector::GetData<double>(left_entries[0]);
-		auto left_y = FlatVector::GetData<double>(left_entries[1]);
-		auto right_x = FlatVector::GetData<double>(right_entries[0]);
-		auto right_y = FlatVector::GetData<double>(right_entries[1]);
+		auto left_x = FlatVector::GetDataMutable<double>(left_entries[0]);
+		auto left_y = FlatVector::GetDataMutable<double>(left_entries[1]);
+		auto right_x = FlatVector::GetDataMutable<double>(right_entries[0]);
+		auto right_y = FlatVector::GetDataMutable<double>(right_entries[1]);
 
-		auto out_data = FlatVector::GetData<double>(result);
+		auto out_data = FlatVector::GetDataMutable<double>(result);
 		for (idx_t i = 0; i < count; i++) {
 			out_data[i] = std::sqrt(std::pow(left_x[i] - right_x[i], 2) + std::pow(left_y[i] - right_y[i], 2));
 		}
@@ -2431,8 +2429,8 @@ struct ST_Distance {
 		auto &p_children = StructVector::GetEntries(in_point);
 		auto &p_x = p_children[0];
 		auto &p_y = p_children[1];
-		auto p_x_data = FlatVector::GetData<double>(p_x);
-		auto p_y_data = FlatVector::GetData<double>(p_y);
+		auto p_x_data = FlatVector::GetDataMutable<double>(p_x);
+		auto p_y_data = FlatVector::GetDataMutable<double>(p_y);
 
 		// Set up the line vectors
 		in_line.Flatten(count);
@@ -2441,11 +2439,11 @@ struct ST_Distance {
 		auto &children = StructVector::GetEntries(inner);
 		auto &x = children[0];
 		auto &y = children[1];
-		auto x_data = FlatVector::GetData<double>(x);
-		auto y_data = FlatVector::GetData<double>(y);
+		auto x_data = FlatVector::GetDataMutable<double>(x);
+		auto y_data = FlatVector::GetDataMutable<double>(y);
 		auto lines = ListVector::GetData(in_line);
 
-		auto result_data = FlatVector::GetData<double>(result);
+		auto result_data = FlatVector::GetDataMutable<double>(result);
 		for (idx_t i = 0; i < count; i++) {
 			auto offset = lines[i].offset;
 			auto length = lines[i].length;
@@ -2905,7 +2903,7 @@ struct ST_Dump {
 			auto &result_path_vec = result_list_children[1];
 
 			// The child geometries must share the same properties as the parent geometry
-			auto geom_data = FlatVector::GetData<string_t>(result_geom_vec);
+			auto geom_data = FlatVector::GetDataMutable<string_t>(result_geom_vec);
 			for (idx_t i = 0; i < geom_length; i++) {
 				// Write the geometry
 				auto item_blob = std::get<0>(items[i]);
@@ -2927,7 +2925,7 @@ struct ST_Dump {
 				path_entries[geom_offset + i].length = path_length;
 
 				auto &path_data_vec = ListVector::GetEntry(result_path_vec);
-				auto path_data = FlatVector::GetData<int32_t>(path_data_vec);
+				auto path_data = FlatVector::GetDataMutable<int32_t>(path_data_vec);
 
 				for (idx_t j = 0; j < path_length; j++) {
 					path_data[path_offset + j] = path[j];
@@ -3081,10 +3079,10 @@ struct ST_Extent {
 		auto &lstate = LocalState::ResetAndGet(state);
 
 		auto &bbox_vec = StructVector::GetEntries(result);
-		const auto min_x_data = FlatVector::GetData<double>(bbox_vec[0]);
-		const auto min_y_data = FlatVector::GetData<double>(bbox_vec[1]);
-		const auto max_x_data = FlatVector::GetData<double>(bbox_vec[2]);
-		const auto max_y_data = FlatVector::GetData<double>(bbox_vec[3]);
+		const auto min_x_data = FlatVector::GetDataMutable<double>(bbox_vec[0]);
+		const auto min_y_data = FlatVector::GetDataMutable<double>(bbox_vec[1]);
+		const auto max_x_data = FlatVector::GetDataMutable<double>(bbox_vec[2]);
+		const auto max_y_data = FlatVector::GetDataMutable<double>(bbox_vec[3]);
 
 		UnifiedVectorFormat input_vdata;
 		args.data[0].ToUnifiedFormat(args.size(), input_vdata);
@@ -3171,10 +3169,10 @@ struct ST_Extent_Approx {
 		auto &input = args.data[0];
 
 		auto &struct_vec = StructVector::GetEntries(result);
-		const auto min_x_data = FlatVector::GetData<float>(struct_vec[0]);
-		const auto min_y_data = FlatVector::GetData<float>(struct_vec[1]);
-		const auto max_x_data = FlatVector::GetData<float>(struct_vec[2]);
-		const auto max_y_data = FlatVector::GetData<float>(struct_vec[3]);
+		const auto min_x_data = FlatVector::GetDataMutable<float>(struct_vec[0]);
+		const auto min_y_data = FlatVector::GetDataMutable<float>(struct_vec[1]);
+		const auto max_x_data = FlatVector::GetDataMutable<float>(struct_vec[2]);
+		const auto max_y_data = FlatVector::GetDataMutable<float>(struct_vec[3]);
 
 		UnifiedVectorFormat input_vdata;
 		input.ToUnifiedFormat(count, input_vdata);
@@ -3252,7 +3250,7 @@ struct Op_IntersectApprox {
         auto &box = args.data[0];
         auto &geom = args.data[1];
 
-        auto result_data = FlatVector::GetData<bool>(result);
+        auto result_data = FlatVector::GetDataMutable<bool>(result);
 
         // Convert box to unified format
         UnifiedVectorFormat box_vdata;
@@ -3405,8 +3403,8 @@ struct ST_ExteriorRing {
 		auto ring_entries = ListVector::GetData(ring_vec);
 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
-		auto poly_x_data = FlatVector::GetData<double>(vertex_vec_children[0]);
-		auto poly_y_data = FlatVector::GetData<double>(vertex_vec_children[1]);
+		auto poly_x_data = FlatVector::GetDataMutable<double>(vertex_vec_children[0]);
+		auto poly_y_data = FlatVector::GetDataMutable<double>(vertex_vec_children[1]);
 
 		auto count = args.size();
 		UnifiedVectorFormat poly_format;
@@ -3433,8 +3431,8 @@ struct ST_ExteriorRing {
 
 		auto line_entries = ListVector::GetData(line_vec);
 		auto &line_coord_vec = StructVector::GetEntries(ListVector::GetEntry(line_vec));
-		auto line_data_x = FlatVector::GetData<double>(line_coord_vec[0]);
-		auto line_data_y = FlatVector::GetData<double>(line_coord_vec[1]);
+		auto line_data_x = FlatVector::GetDataMutable<double>(line_coord_vec[0]);
+		auto line_data_y = FlatVector::GetDataMutable<double>(line_coord_vec[1]);
 
 		// Now we can fill the result vector
 		idx_t line_data_offset = 0;
@@ -3525,12 +3523,12 @@ struct ST_FlipCoordinates {
 		input.Flatten(count);
 
 		auto &coords_in = StructVector::GetEntries(input);
-		auto x_data_in = FlatVector::GetData<double>(coords_in[0]);
-		auto y_data_in = FlatVector::GetData<double>(coords_in[1]);
+		auto x_data_in = FlatVector::GetDataMutable<double>(coords_in[0]);
+		auto y_data_in = FlatVector::GetDataMutable<double>(coords_in[1]);
 
 		auto &coords_out = StructVector::GetEntries(result);
-		auto x_data_out = FlatVector::GetData<double>(coords_out[0]);
-		auto y_data_out = FlatVector::GetData<double>(coords_out[1]);
+		auto x_data_out = FlatVector::GetDataMutable<double>(coords_out[0]);
+		auto y_data_out = FlatVector::GetDataMutable<double>(coords_out[1]);
 
 		memcpy(x_data_out, y_data_in, count * sizeof(double));
 		memcpy(y_data_out, x_data_in, count * sizeof(double));
@@ -3552,8 +3550,8 @@ struct ST_FlipCoordinates {
 
 		auto &coord_vec_in = ListVector::GetEntry(input);
 		auto &coords_in = StructVector::GetEntries(coord_vec_in);
-		auto x_data_in = FlatVector::GetData<double>(coords_in[0]);
-		auto y_data_in = FlatVector::GetData<double>(coords_in[1]);
+		auto x_data_in = FlatVector::GetDataMutable<double>(coords_in[0]);
+		auto y_data_in = FlatVector::GetDataMutable<double>(coords_in[1]);
 
 		auto coord_count = ListVector::GetListSize(input);
 		ListVector::Reserve(result, coord_count);
@@ -3565,8 +3563,8 @@ struct ST_FlipCoordinates {
 
 		auto &coord_vec_out = ListVector::GetEntry(result);
 		auto &coords_out = StructVector::GetEntries(coord_vec_out);
-		auto x_data_out = FlatVector::GetData<double>(coords_out[0]);
-		auto y_data_out = FlatVector::GetData<double>(coords_out[1]);
+		auto x_data_out = FlatVector::GetDataMutable<double>(coords_out[0]);
+		auto y_data_out = FlatVector::GetDataMutable<double>(coords_out[1]);
 
 		memcpy(x_data_out, y_data_in, coord_count * sizeof(double));
 		memcpy(y_data_out, x_data_in, coord_count * sizeof(double));
@@ -3591,8 +3589,8 @@ struct ST_FlipCoordinates {
 
 		auto &coord_vec_in = ListVector::GetEntry(ring_vec_in);
 		auto &coords_in = StructVector::GetEntries(coord_vec_in);
-		auto x_data_in = FlatVector::GetData<double>(coords_in[0]);
-		auto y_data_in = FlatVector::GetData<double>(coords_in[1]);
+		auto x_data_in = FlatVector::GetDataMutable<double>(coords_in[0]);
+		auto y_data_in = FlatVector::GetDataMutable<double>(coords_in[1]);
 
 		auto coord_count = ListVector::GetListSize(ring_vec_in);
 
@@ -3612,8 +3610,8 @@ struct ST_FlipCoordinates {
 
 		auto &coord_vec_out = ListVector::GetEntry(ring_vec_out);
 		auto &coords_out = StructVector::GetEntries(coord_vec_out);
-		auto x_data_out = FlatVector::GetData<double>(coords_out[0]);
-		auto y_data_out = FlatVector::GetData<double>(coords_out[1]);
+		auto x_data_out = FlatVector::GetDataMutable<double>(coords_out[0]);
+		auto y_data_out = FlatVector::GetDataMutable<double>(coords_out[1]);
 
 		memcpy(x_data_out, y_data_in, coord_count * sizeof(double));
 		memcpy(y_data_out, x_data_in, coord_count * sizeof(double));
@@ -3635,16 +3633,16 @@ struct ST_FlipCoordinates {
 		input.Flatten(count);
 
 		auto &children_in = StructVector::GetEntries(input);
-		auto min_x_in = FlatVector::GetData<double>(children_in[0]);
-		auto min_y_in = FlatVector::GetData<double>(children_in[1]);
-		auto max_x_in = FlatVector::GetData<double>(children_in[2]);
-		auto max_y_in = FlatVector::GetData<double>(children_in[3]);
+		auto min_x_in = FlatVector::GetDataMutable<double>(children_in[0]);
+		auto min_y_in = FlatVector::GetDataMutable<double>(children_in[1]);
+		auto max_x_in = FlatVector::GetDataMutable<double>(children_in[2]);
+		auto max_y_in = FlatVector::GetDataMutable<double>(children_in[3]);
 
 		auto &children_out = StructVector::GetEntries(result);
-		auto min_x_out = FlatVector::GetData<double>(children_out[0]);
-		auto min_y_out = FlatVector::GetData<double>(children_out[1]);
-		auto max_x_out = FlatVector::GetData<double>(children_out[2]);
-		auto max_y_out = FlatVector::GetData<double>(children_out[3]);
+		auto min_x_out = FlatVector::GetDataMutable<double>(children_out[0]);
+		auto min_y_out = FlatVector::GetDataMutable<double>(children_out[1]);
+		auto max_x_out = FlatVector::GetDataMutable<double>(children_out[2]);
+		auto max_y_out = FlatVector::GetDataMutable<double>(children_out[3]);
 
 		memcpy(min_x_out, min_y_in, count * sizeof(double));
 		memcpy(min_y_out, min_x_in, count * sizeof(double));
@@ -4753,15 +4751,15 @@ struct ST_GeomFromWKB {
 		input.Flatten(count);
 
 		auto &point_children = StructVector::GetEntries(result);
-		const auto x_data = FlatVector::GetData<double>(point_children[0]);
-		const auto y_data = FlatVector::GetData<double>(point_children[1]);
+		const auto x_data = FlatVector::GetDataMutable<double>(point_children[0]);
+		const auto y_data = FlatVector::GetDataMutable<double>(point_children[1]);
 
 		sgl::wkb_reader reader(alloc);
 		reader.set_allow_mixed_zm(true);
 		reader.set_nan_as_empty(true);
 
 		for (idx_t i = 0; i < count; i++) {
-			const auto &wkb = FlatVector::GetData<string_t>(input)[i];
+			const auto &wkb = FlatVector::GetDataMutable<string_t>(input)[i];
 
 			const auto wkb_ptr = wkb.GetDataUnsafe();
 			const auto wkb_len = wkb.GetSize();
@@ -4836,8 +4834,8 @@ struct ST_GeomFromWKB {
 			auto &children = StructVector::GetEntries(inner);
 			auto &x_child = children[0];
 			auto &y_child = children[1];
-			auto x_data = FlatVector::GetData<double>(x_child);
-			auto y_data = FlatVector::GetData<double>(y_child);
+			auto x_data = FlatVector::GetDataMutable<double>(x_child);
+			auto y_data = FlatVector::GetDataMutable<double>(y_child);
 
 			for (idx_t j = 0; j < line_size; j++) {
 				const auto vertex = geom.get_vertex_xy(j);
@@ -4920,8 +4918,8 @@ struct ST_GeomFromWKB {
 					auto &children = StructVector::GetEntries(inner);
 					auto &x_child = children[0];
 					auto &y_child = children[1];
-					auto x_data = FlatVector::GetData<double>(x_child);
-					auto y_data = FlatVector::GetData<double>(y_child);
+					auto x_data = FlatVector::GetDataMutable<double>(x_child);
+					auto y_data = FlatVector::GetDataMutable<double>(y_child);
 
 					for (idx_t k = 0; k < point_count; k++) {
 						const auto vertex = ring->get_vertex_xy(k);
@@ -6198,8 +6196,8 @@ struct ST_InteriorRingN {
 		auto ring_entries = ListVector::GetData(ring_vec);
 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
-		auto poly_x_data = FlatVector::GetData<double>(vertex_vec_children[0]);
-		auto poly_y_data = FlatVector::GetData<double>(vertex_vec_children[1]);
+		auto poly_x_data = FlatVector::GetDataMutable<double>(vertex_vec_children[0]);
+		auto poly_y_data = FlatVector::GetDataMutable<double>(vertex_vec_children[1]);
 
 		auto count = args.size();
 		UnifiedVectorFormat poly_format;
@@ -6255,8 +6253,8 @@ struct ST_InteriorRingN {
 
 		auto line_entries = ListVector::GetData(line_vec);
 		auto &line_coord_vec = StructVector::GetEntries(ListVector::GetEntry(line_vec));
-		auto line_data_x = FlatVector::GetData<double>(line_coord_vec[0]);
-		auto line_data_y = FlatVector::GetData<double>(line_coord_vec[1]);
+		auto line_data_x = FlatVector::GetDataMutable<double>(line_coord_vec[0]);
+		auto line_data_y = FlatVector::GetDataMutable<double>(line_coord_vec[1]);
 
 		// Fill results
 		idx_t line_data_offset = 0;
@@ -6719,8 +6717,8 @@ struct ST_Length {
 
 		auto &coord_vec = ListVector::GetEntry(line_vec);
 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
-		auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
-		auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+		auto x_data = FlatVector::GetDataMutable<double>(coord_vec_children[0]);
+		auto y_data = FlatVector::GetDataMutable<double>(coord_vec_children[1]);
 
 		UnaryExecutor::Execute<list_entry_t, double>(line_vec, result, count, [&](const list_entry_t &line) {
 			auto offset = line.offset;
@@ -7243,10 +7241,10 @@ struct ST_MakeBox2D {
 		auto &lstate = LocalState::ResetAndGet(state);
 
 		auto &bbox_vec = StructVector::GetEntries(result);
-		const auto min_x_data = FlatVector::GetData<double>(bbox_vec[0]);
-		const auto min_y_data = FlatVector::GetData<double>(bbox_vec[1]);
-		const auto max_x_data = FlatVector::GetData<double>(bbox_vec[2]);
-		const auto max_y_data = FlatVector::GetData<double>(bbox_vec[3]);
+		const auto min_x_data = FlatVector::GetDataMutable<double>(bbox_vec[0]);
+		const auto min_y_data = FlatVector::GetDataMutable<double>(bbox_vec[1]);
+		const auto max_x_data = FlatVector::GetDataMutable<double>(bbox_vec[2]);
+		const auto max_y_data = FlatVector::GetDataMutable<double>(bbox_vec[3]);
 
 		UnifiedVectorFormat input_vdata1;
 		UnifiedVectorFormat input_vdata2;
@@ -7720,8 +7718,8 @@ struct ST_Perimeter {
 		auto ring_entries = ListVector::GetData(ring_vec);
 		auto &coord_vec = ListVector::GetEntry(ring_vec);
 		auto &coord_vec_children = StructVector::GetEntries(coord_vec);
-		auto x_data = FlatVector::GetData<double>(coord_vec_children[0]);
-		auto y_data = FlatVector::GetData<double>(coord_vec_children[1]);
+		auto x_data = FlatVector::GetDataMutable<double>(coord_vec_children[0]);
+		auto y_data = FlatVector::GetDataMutable<double>(coord_vec_children[1]);
 
 		UnaryExecutor::Execute<list_entry_t, double>(input, result, count, [&](list_entry_t polygon) {
 			auto polygon_offset = polygon.offset;
@@ -8135,14 +8133,14 @@ struct ST_PointN {
 		auto line_vertex_entries = ListVector::GetData(geom_vec);
 		auto &line_vertex_vec = ListVector::GetEntry(geom_vec);
 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
-		auto line_x_data = FlatVector::GetData<double>(line_vertex_vec_children[0]);
-		auto line_y_data = FlatVector::GetData<double>(line_vertex_vec_children[1]);
+		auto line_x_data = FlatVector::GetDataMutable<double>(line_vertex_vec_children[0]);
+		auto line_y_data = FlatVector::GetDataMutable<double>(line_vertex_vec_children[1]);
 
 		auto &point_vertex_children = StructVector::GetEntries(result);
-		auto point_x_data = FlatVector::GetData<double>(point_vertex_children[0]);
-		auto point_y_data = FlatVector::GetData<double>(point_vertex_children[1]);
+		auto point_x_data = FlatVector::GetDataMutable<double>(point_vertex_children[0]);
+		auto point_y_data = FlatVector::GetDataMutable<double>(point_vertex_children[1]);
 
-		auto index_data = FlatVector::GetData<int32_t>(index_vec);
+		auto index_data = FlatVector::GetDataMutable<int32_t>(index_vec);
 
 		for (idx_t out_row_idx = 0; out_row_idx < count; out_row_idx++) {
 
@@ -8433,8 +8431,8 @@ struct ST_RemoveRepeatedPoints {
 
 		auto in_line_entries = ListVector::GetData(input);
 		auto &in_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(input));
-		auto in_x_data = FlatVector::GetData<double>(in_line_vertex_vec[0]);
-		auto in_y_data = FlatVector::GetData<double>(in_line_vertex_vec[1]);
+		auto in_x_data = FlatVector::GetDataMutable<double>(in_line_vertex_vec[0]);
+		auto in_y_data = FlatVector::GetDataMutable<double>(in_line_vertex_vec[1]);
 
 		auto out_line_entries = ListVector::GetData(result);
 		auto &out_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(result));
@@ -8455,8 +8453,8 @@ struct ST_RemoveRepeatedPoints {
 			if (in_length < 3) {
 
 				ListVector::Reserve(result, out_offset + in_length);
-				auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
-				auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+				auto out_x_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[0]);
+				auto out_y_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[1]);
 
 				// If the line has less than 3 points, we can't remove any points
 				// so we just copy the line
@@ -8493,8 +8491,8 @@ struct ST_RemoveRepeatedPoints {
 			if (points_to_keep == 1) {
 				out_line_entries[out_row_idx] = list_entry_t {out_offset, 2};
 				ListVector::Reserve(result, out_offset + 2);
-				auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
-				auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+				auto out_x_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[0]);
+				auto out_y_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[1]);
 				out_x_data[out_offset] = in_x_data[in_offset];
 				out_y_data[out_offset] = in_y_data[in_offset];
 				out_x_data[out_offset + 1] = in_x_data[in_offset + in_length - 1];
@@ -8508,8 +8506,8 @@ struct ST_RemoveRepeatedPoints {
 
 			// Second pass, copy the points we need to keep
 			ListVector::Reserve(result, out_offset + points_to_keep);
-			auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
-			auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+			auto out_x_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[0]);
+			auto out_y_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[1]);
 
 			// Copy the first point
 			out_x_data[out_offset] = in_x_data[in_offset];
@@ -8555,8 +8553,8 @@ struct ST_RemoveRepeatedPoints {
 
 		auto in_line_entries = ListVector::GetData(input);
 		auto &in_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(input));
-		auto in_x_data = FlatVector::GetData<double>(in_line_vertex_vec[0]);
-		auto in_y_data = FlatVector::GetData<double>(in_line_vertex_vec[1]);
+		auto in_x_data = FlatVector::GetDataMutable<double>(in_line_vertex_vec[0]);
+		auto in_y_data = FlatVector::GetDataMutable<double>(in_line_vertex_vec[1]);
 
 		auto out_line_entries = ListVector::GetData(result);
 		auto &out_line_vertex_vec = StructVector::GetEntries(ListVector::GetEntry(result));
@@ -8581,8 +8579,8 @@ struct ST_RemoveRepeatedPoints {
 			if (in_length < 3) {
 
 				ListVector::Reserve(result, out_offset + in_length);
-				auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
-				auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+				auto out_x_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[0]);
+				auto out_y_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[1]);
 
 				// If the line has less than 3 points, we can't remove any points
 				// so we just copy the line
@@ -8620,8 +8618,8 @@ struct ST_RemoveRepeatedPoints {
 			if (points_to_keep == 1) {
 				out_line_entries[out_row_idx] = list_entry_t {out_offset, 2};
 				ListVector::Reserve(result, out_offset + 2);
-				auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
-				auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+				auto out_x_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[0]);
+				auto out_y_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[1]);
 				out_x_data[out_offset] = in_x_data[in_offset];
 				out_y_data[out_offset] = in_y_data[in_offset];
 				out_x_data[out_offset + 1] = in_x_data[in_offset + in_length - 1];
@@ -8635,8 +8633,8 @@ struct ST_RemoveRepeatedPoints {
 
 			// Second pass, copy the points we need to keep
 			ListVector::Reserve(result, out_offset + points_to_keep);
-			auto out_x_data = FlatVector::GetData<double>(out_line_vertex_vec[0]);
-			auto out_y_data = FlatVector::GetData<double>(out_line_vertex_vec[1]);
+			auto out_x_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[0]);
+			auto out_y_data = FlatVector::GetDataMutable<double>(out_line_vertex_vec[1]);
 
 			// Copy the first point
 			out_x_data[out_offset] = in_x_data[in_offset];
@@ -8762,12 +8760,12 @@ struct ST_StartPoint {
 		auto line_vertex_entries = ListVector::GetData(geom_vec);
 		auto &line_vertex_vec = ListVector::GetEntry(geom_vec);
 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
-		auto line_x_data = FlatVector::GetData<double>(line_vertex_vec_children[0]);
-		auto line_y_data = FlatVector::GetData<double>(line_vertex_vec_children[1]);
+		auto line_x_data = FlatVector::GetDataMutable<double>(line_vertex_vec_children[0]);
+		auto line_y_data = FlatVector::GetDataMutable<double>(line_vertex_vec_children[1]);
 
 		auto &point_vertex_children = StructVector::GetEntries(result);
-		auto point_x_data = FlatVector::GetData<double>(point_vertex_children[0]);
-		auto point_y_data = FlatVector::GetData<double>(point_vertex_children[1]);
+		auto point_x_data = FlatVector::GetDataMutable<double>(point_vertex_children[0]);
+		auto point_y_data = FlatVector::GetDataMutable<double>(point_vertex_children[1]);
 
 		for (idx_t out_row_idx = 0; out_row_idx < count; out_row_idx++) {
 			auto in_row_idx = geom_format.sel->get_index(out_row_idx);
@@ -8885,12 +8883,12 @@ struct ST_EndPoint {
 		auto line_vertex_entries = ListVector::GetData(geom_vec);
 		auto &line_vertex_vec = ListVector::GetEntry(geom_vec);
 		auto &line_vertex_vec_children = StructVector::GetEntries(line_vertex_vec);
-		auto line_x_data = FlatVector::GetData<double>(line_vertex_vec_children[0]);
-		auto line_y_data = FlatVector::GetData<double>(line_vertex_vec_children[1]);
+		auto line_x_data = FlatVector::GetDataMutable<double>(line_vertex_vec_children[0]);
+		auto line_y_data = FlatVector::GetDataMutable<double>(line_vertex_vec_children[1]);
 
 		auto &point_vertex_children = StructVector::GetEntries(result);
-		auto point_x_data = FlatVector::GetData<double>(point_vertex_children[0]);
-		auto point_y_data = FlatVector::GetData<double>(point_vertex_children[1]);
+		auto point_x_data = FlatVector::GetDataMutable<double>(point_vertex_children[0]);
+		auto point_y_data = FlatVector::GetDataMutable<double>(point_vertex_children[1]);
 
 		for (idx_t out_row_idx = 0; out_row_idx < count; out_row_idx++) {
 			auto in_row_idx = geom_format.sel->get_index(out_row_idx);
@@ -9209,7 +9207,7 @@ struct VertexAggFunctionBase {
 		auto &line_coords_vec = StructVector::GetEntries(line_coords);
 
 		const auto axis = OP::ORDINATE == VertexOrdinate::X ? 0 : 1;
-		auto ordinate_data = FlatVector::GetData<double>(line_coords_vec[axis]);
+		auto ordinate_data = FlatVector::GetDataMutable<double>(line_coords_vec[axis]);
 
 		UnaryExecutor::Execute<list_entry_t, double>(
 		    line_vec, result, args.size(), [&](const list_entry_t &line) -> optional<double> {
@@ -9245,7 +9243,7 @@ struct VertexAggFunctionBase {
 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
 		const auto axis = OP::ORDINATE == VertexOrdinate::X ? 0 : 1;
-		auto ordinate_data = FlatVector::GetData<double>(vertex_vec_children[axis]);
+		auto ordinate_data = FlatVector::GetDataMutable<double>(vertex_vec_children[axis]);
 
 		UnaryExecutor::Execute<list_entry_t, double>(
 		    input, result, count, [&](const list_entry_t &polygon) -> optional<double> {

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -1005,7 +1005,7 @@ struct ST_AsWKB {
 	// GEOMETRY
 	//------------------------------------------------------------------------------------------------------------------
 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
-		return Geometry::ToBinary(args.data[0], result, args.size());
+		return Geometry::ToBinary(args.data[0], result);
 	}
 
 	//------------------------------------------------------------------------------------------------------------------
@@ -1276,7 +1276,7 @@ struct ST_AsSVG {
 		vector<char> buffer;
 
 		TernaryExecutor::Execute<string_t, bool, int32_t, string_t>(
-		    args.data[0], args.data[1], args.data[2], result, args.size(),
+		    args.data[0], args.data[1], args.data[2], result,
 		    [&](const string_t &blob, const bool rel, const int32_t max_digits) {
 			    // Clear buffer
 			    buffer.clear();
@@ -2687,7 +2687,7 @@ struct ST_DistanceWithin {
 			auto &dst_vec = args.data[2];
 
 			TernaryExecutor::Execute<string_t, string_t, double, bool>(
-			    lhs_vec, rhs_vec, dst_vec, result, count,
+			    lhs_vec, rhs_vec, dst_vec, result,
 			    [&](const string_t &lhs_blob, const string_t &rhs_blob, double distance) {
 				    sgl::prepared_geometry lhs_geom;
 				    sgl::prepared_geometry rhs_geom;
@@ -3003,7 +3003,7 @@ struct ST_Expand {
 		auto &lstate = LocalState::ResetAndGet(state);
 
 		BinaryExecutor::Execute<string_t, double, string_t>(
-		    args.data[0], args.data[1], result, args.size(), [&](const string_t &blob, double distance) {
+		    args.data[0], args.data[1], result, [&](const string_t &blob, double distance) {
 			    sgl::geometry geom;
 			    lstate.Deserialize(blob, geom);
 			    auto bbox = sgl::extent_xy::smallest();
@@ -3763,7 +3763,7 @@ struct ST_ForceBase {
 			auto &m_values = args.data[2];
 
 			TernaryExecutor::Execute<string_t, double, double, string_t>(
-			    input, z_values, m_values, result, count, [&](const string_t &blob, double z, double m) {
+			    input, z_values, m_values, result, [&](const string_t &blob, double z, double m) {
 				    sgl::geometry geom;
 				    lstate.Deserialize(blob, geom);
 				    sgl::ops::force_zm(alloc, geom, true, true, z, m);
@@ -3928,7 +3928,7 @@ struct ST_GeometryType {
 	//------------------------------------------------------------------------------------------------------------------
 	static void ExecuteGeometry(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
-		UnaryExecutor::Execute<string_t, uint8_t>(args.data[0], result, args.size(), [&](const string_t &blob) {
+		UnaryExecutor::Execute<string_t, uint8_t>(args.data[0], result, [&](const string_t &blob) {
 			// TODO: Peek dont deserialize
 
 			sgl::geometry geom;
@@ -5242,7 +5242,7 @@ struct ST_LineInterpolatePoints {
 		auto &alloc = lstate.GetAllocator();
 
 		TernaryExecutor::Execute<string_t, double, bool, string_t>(
-		    args.data[0], args.data[1], args.data[2], result, args.size(),
+		    args.data[0], args.data[1], args.data[2], result,
 		    [&](const string_t &blob, const double fraction, const bool repeat) {
 			    sgl::geometry geom;
 			    lstate.Deserialize(blob, geom);
@@ -5394,7 +5394,7 @@ struct ST_LineSubstring {
 		auto &alloc = lstate.GetAllocator();
 
 		TernaryExecutor::Execute<string_t, double, double, string_t>(
-		    args.data[0], args.data[1], args.data[2], result, args.size(),
+		    args.data[0], args.data[1], args.data[2], result,
 		    [&](const string_t &blob, const double start_fraction, const double end_fraction) {
 			    sgl::geometry geom;
 			    lstate.Deserialize(blob, geom);
@@ -5470,7 +5470,7 @@ struct ST_LocateAlong {
 		auto &alloc = lstate.GetAllocator();
 
 		TernaryExecutor::Execute<string_t, double, double, string_t>(
-		    args.data[0], args.data[1], args.data[2], result, args.size(),
+		    args.data[0], args.data[1], args.data[2], result,
 		    [&](const string_t &blob, const double measure, const double offset) {
 			    // Reset after each execution, because this can be quite memory hungry
 			    lstate.GetArena().Reset();
@@ -8359,7 +8359,7 @@ struct ST_QuadKey {
 		auto &lev_in = args.data[2];
 
 		TernaryExecutor::Execute<double, double, int32_t, string_t>(
-		    lon_in, lat_in, lev_in, result, args.size(), [&](const double lon, const double lat, const int32_t level) {
+		    lon_in, lat_in, lev_in, result, [&](const double lon, const double lat, const int32_t level) {
 			    if (level < 1 || level > 23) {
 				    throw InvalidInputException("ST_QuadKey: Level must be between 1 and 23");
 			    }

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -2658,8 +2658,11 @@ struct ST_DistanceWithin {
 	};
 
 	// We try to constant-fold the distance parameter here, because it's a very common have a constant distance
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+
+		auto &arguments = input.GetArguments();
+		auto &bound_function = input.GetBoundFunction();
+		auto &context = input.GetClientContext();
 
 		if (arguments.back()->IsFoldable()) {
 			const auto dist_expr = ExpressionExecutor::EvaluateScalar(context, *arguments.back());
@@ -2885,7 +2888,7 @@ struct ST_Dump {
 			}
 
 			// Push to the result vector
-			auto result_entries = ListVector::GetData(result);
+			auto result_entries = FlatVector::GetDataMutable<list_entry_t>(result);
 
 			auto geom_offset = total_geom_count;
 			auto geom_length = items.size();
@@ -2920,7 +2923,7 @@ struct ST_Dump {
 				ListVector::Reserve(result_path_vec, total_path_count);
 				ListVector::SetListSize(result_path_vec, total_path_count);
 
-				auto path_entries = ListVector::GetData(result_path_vec);
+				auto path_entries = FlatVector::GetDataMutable<list_entry_t>(result_path_vec);
 
 				path_entries[geom_offset + i].offset = path_offset;
 				path_entries[geom_offset + i].length = path_length;
@@ -3559,8 +3562,8 @@ struct ST_FlipCoordinates {
 		ListVector::Reserve(result, coord_count);
 		ListVector::SetListSize(result, coord_count);
 
-		auto line_entries_in = ListVector::GetData(input);
-		auto line_entries_out = ListVector::GetData(result);
+		auto line_entries_in = FlatVector::GetDataMutable<list_entry_t>(input);
+		auto line_entries_out = FlatVector::GetDataMutable<list_entry_t>(result);
 		memcpy(line_entries_out, line_entries_in, count * sizeof(list_entry_t));
 
 		auto &coord_vec_out = ListVector::GetEntry(result);
@@ -3602,12 +3605,12 @@ struct ST_FlipCoordinates {
 		ListVector::Reserve(ring_vec_out, coord_count);
 		ListVector::SetListSize(ring_vec_out, coord_count);
 
-		auto ring_entries_in = ListVector::GetData(input);
-		auto ring_entries_out = ListVector::GetData(result);
+		auto ring_entries_in = FlatVector::GetDataMutable<list_entry_t>(input);
+		auto ring_entries_out = FlatVector::GetDataMutable<list_entry_t>(result);
 		memcpy(ring_entries_out, ring_entries_in, count * sizeof(list_entry_t));
 
-		auto coord_entries_in = ListVector::GetData(ring_vec_in);
-		auto coord_entries_out = ListVector::GetData(ring_vec_out);
+		auto coord_entries_in = FlatVector::GetDataMutable<list_entry_t>(ring_vec_in);
+		auto coord_entries_out = FlatVector::GetDataMutable<list_entry_t>(ring_vec_out);
 		memcpy(coord_entries_out, coord_entries_in, ring_count * sizeof(list_entry_t));
 
 		auto &coord_vec_out = ListVector::GetEntry(ring_vec_out);
@@ -3910,8 +3913,7 @@ struct ST_GeometryType {
 	static constexpr uint8_t LEGACY_GEOMETRYCOLLECTION_TYPE = 6;
 	static constexpr uint8_t LEGACY_UNKNOWN_TYPE = 7;
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
 		// Create an enum type for all geometry types
 		// Ensure that these are in the same order as the LegacyGeometryType enum
 		const vector<string> enum_values = {"POINT", "LINESTRING", "POLYGON", "MULTIPOINT", "MULTILINESTRING",
@@ -3919,7 +3921,7 @@ struct ST_GeometryType {
 		                                    // or...
 		                                    "UNKNOWN"};
 
-		bound_function.return_type = GeoTypes::CreateEnumType("GEOMETRY_TYPE", enum_values);
+		input.GetBoundFunction().SetReturnType(GeoTypes::CreateEnumType("GEOMETRY_TYPE", enum_values));
 		return nullptr;
 	}
 
@@ -4591,8 +4593,10 @@ struct ST_GeomFromText {
 		bool ignore_invalid = false;
 	};
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto &arguments = input.GetArguments();
+		auto &context = input.GetClientContext();
+
 		if (arguments.empty()) {
 			throw InvalidInputException("ST_GeomFromText requires at least one argument");
 		}
@@ -4800,7 +4804,7 @@ struct ST_GeomFromWKB {
 		wkb_blobs.Flatten(count);
 
 		auto &inner = ListVector::GetEntry(result);
-		const auto lines = ListVector::GetData(result);
+		const auto lines = FlatVector::GetDataMutable<list_entry_t>(result);
 		const auto wkb_data = FlatVector::GetDataMutable<string_t>(wkb_blobs);
 
 		idx_t total_size = 0;
@@ -4872,7 +4876,7 @@ struct ST_GeomFromWKB {
 
 		// Set up output data
 		auto &ring_vec = ListVector::GetEntry(result);
-		auto polygons = ListVector::GetData(result);
+		auto polygons = FlatVector::GetDataMutable<list_entry_t>(result);
 
 		idx_t total_ring_count = 0;
 		idx_t total_point_count = 0;
@@ -4914,7 +4918,7 @@ struct ST_GeomFromWKB {
 					const auto point_count = ring->get_vertex_count();
 
 					ListVector::Reserve(ring_vec, total_point_count + point_count);
-					auto ring_entries = ListVector::GetData(ring_vec);
+					auto ring_entries = FlatVector::GetDataMutable<list_entry_t>(ring_vec);
 					auto &inner = ListVector::GetEntry(ring_vec);
 
 					auto &children = StructVector::GetEntries(inner);
@@ -5452,8 +5456,9 @@ struct ST_LocateAlong {
 	//------------------------------------------------------------------------------------------------------------------
 	// Bind
 	//------------------------------------------------------------------------------------------------------------------
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto &arguments = input.GetArguments();
+
 		if (arguments.size() == 2) {
 			// Push back offset constant
 			arguments.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(0.0)));
@@ -5554,8 +5559,9 @@ struct ST_LocateBetween {
 	//------------------------------------------------------------------------------------------------------------------
 	// Bind
 	//------------------------------------------------------------------------------------------------------------------
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto &arguments = input.GetArguments();
+
 		if (arguments.size() == 3) {
 			// Push back offset constant
 			arguments.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(0.0)));
@@ -5794,8 +5800,10 @@ struct ST_Distance_Sphere {
 		}
 	};
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &func,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto &context = input.GetClientContext();
+		auto &func = input.GetBoundFunction();
+
 		auto bind_data = make_uniq<BindData>();
 
 		bool is_set = false;
@@ -7606,7 +7614,7 @@ struct ST_NPoints {
 		auto &input = args.data[0];
 		auto count = args.size();
 		auto &ring_vec = ListVector::GetEntry(input);
-		auto ring_entries = ListVector::GetData(ring_vec);
+		auto ring_entries = FlatVector::GetDataMutable<list_entry_t>(ring_vec);
 
 		UnaryExecutor::Execute<list_entry_t, idx_t>(input, result, count, [&](list_entry_t polygon) {
 			auto polygon_offset = polygon.offset;
@@ -9257,7 +9265,7 @@ struct VertexAggFunctionBase {
 		input.ToUnifiedFormat(count, format);
 
 		auto &ring_vec = ListVector::GetEntry(input);
-		auto ring_entries = ListVector::GetData(ring_vec);
+		auto ring_entries = FlatVector::GetDataMutable<list_entry_t>(ring_vec);
 		auto &vertex_vec = ListVector::GetEntry(ring_vec);
 		auto &vertex_vec_children = StructVector::GetEntries(vertex_vec);
 		const auto axis = OP::ORDINATE == VertexOrdinate::X ? 0 : 1;

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -14,7 +14,7 @@
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/common/vector_operations/septenary_executor.hpp"
+#include "duckdb/common/vector_operations/variadic_executor.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
 #include "spatial/util/distance_extract.hpp"
@@ -191,7 +191,7 @@ struct ST_Affine {
 		auto &lstate = LocalState::ResetAndGet(state);
 		auto &alloc = lstate.GetAllocator();
 
-		SeptenaryExecutor::Execute<string_t, double, double, double, double, double, double, string_t>(
+		VariadicExecutor::Execute<string_t, string_t, double, double, double, double, double, double>(
 		    args, result,
 		    [&](const string_t &geom_blob, const double a, const double b, const double d, const double e,
 		        const double xoff, const double yoff) {

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -824,7 +824,7 @@ struct ST_AsGeoJSON {
 
 		JSONAllocator allocator(lstate.GetArena());
 
-		UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t &blob) {
+		UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](const string_t &blob) {
 			sgl::geometry geom;
 			lstate.Deserialize(blob, geom);
 
@@ -2225,9 +2225,9 @@ struct ST_Azimuth {
 	static void ExecuteGeometry(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
 
-		BinaryExecutor::ExecuteWithNulls<string_t, string_t, double>(
+		BinaryExecutor::Execute<string_t, string_t, double>(
 		    args.data[0], args.data[1], result, args.size(),
-		    [&](const string_t &left, const string_t &right, ValidityMask &mask, idx_t idx) {
+		    [&](const string_t &left, const string_t &right) -> optional<double> {
 			    sgl::geometry left_geom;
 			    sgl::geometry right_geom;
 
@@ -2240,8 +2240,7 @@ struct ST_Azimuth {
 			    }
 
 			    if (left_geom.is_empty() || right_geom.is_empty()) {
-				    mask.SetInvalid(idx);
-				    return 0.0;
+				    return nullopt;
 			    }
 
 			    const auto left_xy = left_geom.get_vertex_xy(0);
@@ -2249,8 +2248,7 @@ struct ST_Azimuth {
 
 			    // If the points are the same, return NULL
 			    if (left_xy.x == right_xy.x && left_xy.y == right_xy.y) {
-				    mask.SetInvalid(idx);
-				    return 0.0;
+				    return nullopt;
 			    }
 
 			    return CalcAngle(left_xy.x, left_xy.y, right_xy.x, right_xy.y);
@@ -3375,15 +3373,14 @@ struct ST_ExteriorRing {
 	static void ExecuteGeometry(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
 
-		UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
-		    args.data[0], result, args.size(), [&](const string_t &blob, ValidityMask &mask, const idx_t idx) {
+		UnaryExecutor::Execute<string_t, string_t>(
+		    args.data[0], result, args.size(), [&](const string_t &blob) -> optional<string_t> {
 			    // TODO: Peek dont deserialize
 			    sgl::geometry geom;
 			    lstate.Deserialize(blob, geom);
 
 			    if (geom.get_type() != sgl::geometry_type::POLYGON) {
-				    mask.SetInvalid(idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    if (geom.is_empty()) {
@@ -4638,8 +4635,8 @@ struct ST_GeomFromText {
 
 		sgl::wkt_reader reader(alloc);
 
-		UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
-		    args.data[0], result, args.size(), [&](const string_t &wkt, ValidityMask &mask, idx_t row_idx) {
+		UnaryExecutor::Execute<string_t, string_t>(
+		    args.data[0], result, args.size(), [&](const string_t &wkt) -> optional<string_t> {
 			    const auto wkt_ptr = wkt.GetDataUnsafe();
 			    const auto wkt_len = wkt.GetSize();
 
@@ -4648,8 +4645,7 @@ struct ST_GeomFromText {
 			    if (!reader.try_parse(geom, wkt_ptr, wkt_len)) {
 
 				    if (ignore_invalid) {
-					    mask.SetInvalid(row_idx);
-					    return string_t {};
+					    return nullopt;
 				    }
 				    const auto error = reader.get_error_message();
 				    throw InvalidInputException(error);
@@ -6008,14 +6004,12 @@ struct ST_Hilbert {
 	// GEOMETRY
 	//------------------------------------------------------------------------------------------------------------------
 	static void ExecuteGeometry(DataChunk &args, ExpressionState &state, Vector &result) {
-		UnaryExecutor::ExecuteWithNulls<string_t, uint32_t>(
-		    args.data[0], result, args.size(),
-		    [&](const string_t &geom, ValidityMask &mask, idx_t out_idx) -> uint32_t {
+		UnaryExecutor::Execute<string_t, uint32_t>(
+		    args.data[0], result, args.size(), [&](const string_t &geom) -> optional<uint32_t> {
 			    // TODO: This is shit, dont rely on cached bounds
 			    Box2D<float> bounds;
 			    if (!Serde::TryGetBounds(geom, bounds)) {
-				    mask.SetInvalid(out_idx);
-				    return 0;
+				    return nullopt;
 			    }
 
 			    const auto dx = bounds.min.x + (bounds.max.x - bounds.min.x) / 2;
@@ -6149,28 +6143,25 @@ struct ST_InteriorRingN {
 	static void ExecuteGeometry(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
 
-		BinaryExecutor::ExecuteWithNulls<string_t, int64_t, string_t>(
+		BinaryExecutor::Execute<string_t, int64_t, string_t>(
 		    args.data[0], args.data[1], result, args.size(),
-		    [&](const string_t &blob, const int64_t &n, ValidityMask &mask, idx_t idx) {
+		    [&](const string_t &blob, const int64_t &n) -> optional<string_t> {
 			    sgl::geometry geom;
 			    lstate.Deserialize(blob, geom);
 
 			    // ---- validate geometry ----
 			    if (geom.get_type() != sgl::geometry_type::POLYGON) {
-				    mask.SetInvalid(idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    if (geom.is_empty()) {
 				    // empty polygon → NULL because ring index must be always out of bounds then
-				    mask.SetInvalid(idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    if (n < 1) {
 				    // invalid index → NULL
-				    mask.SetInvalid(idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    const idx_t num_parts = geom.get_part_count(); // includes shell
@@ -6179,8 +6170,7 @@ struct ST_InteriorRingN {
 
 			    if (static_cast<idx_t>(n) > num_interior) {
 				    // ring doesn't exist → NULL
-				    mask.SetInvalid(idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    // interior ring N = part N (because part 0 = shell)
@@ -7511,14 +7501,13 @@ struct ST_NInteriorRings {
 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
 
-		UnaryExecutor::ExecuteWithNulls<string_t, int32_t>(
-		    args.data[0], result, args.size(), [&](const string_t &blob, ValidityMask &validity, idx_t idx) {
+		UnaryExecutor::Execute<string_t, int32_t>(
+		    args.data[0], result, args.size(), [&](const string_t &blob) -> optional<int32_t> {
 			    sgl::geometry geom;
 			    lstate.Deserialize(blob, geom);
 
 			    if (geom.get_type() != sgl::geometry_type::POLYGON) {
-				    validity.SetInvalid(idx);
-				    return 0;
+				    return nullopt;
 			    }
 
 			    const auto n_rings = static_cast<int32_t>(geom.get_part_count());
@@ -8096,17 +8085,16 @@ struct ST_PointN {
 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
 
-		BinaryExecutor::ExecuteWithNulls<string_t, int32_t, string_t>(
+		BinaryExecutor::Execute<string_t, int32_t, string_t>(
 		    args.data[0], args.data[1], result, args.size(),
-		    [&](const string_t &blob, const int32_t index, ValidityMask &mask, const idx_t row_idx) {
+		    [&](const string_t &blob, const int32_t index) -> optional<string_t> {
 			    // TODO: peek type without deserializing
 
 			    sgl::geometry geom;
 			    lstate.Deserialize(blob, geom);
 
 			    if (geom.get_type() != sgl::geometry_type::LINESTRING) {
-				    mask.SetInvalid(row_idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    const auto point_count = geom.get_vertex_count();
@@ -8116,8 +8104,7 @@ struct ST_PointN {
 			    const auto is_above = index > static_cast<int64_t>(point_count);
 
 			    if (is_empty || is_under || is_above) {
-				    mask.SetInvalid(row_idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    const auto vertex_elem = index < 0 ? point_count + index : index - 1;
@@ -8739,20 +8726,18 @@ struct ST_StartPoint {
 	//------------------------------------------------------------------------------------------------------------------
 	static void ExecuteGeometry(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
-		UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
-		    args.data[0], result, args.size(), [&](const string_t &blob, ValidityMask &mask, const idx_t idx) {
+		UnaryExecutor::Execute<string_t, string_t>(
+		    args.data[0], result, args.size(), [&](const string_t &blob) -> optional<string_t> {
 			    // TODO: Peek without deserializing!
 			    sgl::geometry geom;
 			    lstate.Deserialize(blob, geom);
 
 			    if (geom.get_type() != sgl::geometry_type::LINESTRING) {
-				    mask.SetInvalid(idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    if (geom.is_empty()) {
-				    mask.SetInvalid(idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    const auto vertex_array = geom.get_vertex_array();
@@ -8860,20 +8845,18 @@ struct ST_EndPoint {
 	//------------------------------------------------------------------------------------------------------------------
 	static void ExecuteGeometry(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
-		UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
-		    args.data[0], result, args.size(), [&](const string_t &blob, ValidityMask &mask, const idx_t idx) {
+		UnaryExecutor::Execute<string_t, string_t>(
+		    args.data[0], result, args.size(), [&](const string_t &blob) -> optional<string_t> {
 			    // TODO: Peek without deserializing!
 			    sgl::geometry geom;
 			    lstate.Deserialize(blob, geom);
 
 			    if (geom.get_type() != sgl::geometry_type::LINESTRING) {
-				    mask.SetInvalid(idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    if (geom.is_empty()) {
-				    mask.SetInvalid(idx);
-				    return string_t {};
+				    return nullopt;
 			    }
 
 			    const auto vertex_count = geom.get_vertex_count();
@@ -9043,8 +9026,8 @@ struct PointAccessFunctionBase {
 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
 
-		UnaryExecutor::ExecuteWithNulls<string_t, double>(
-		    args.data[0], result, args.size(), [&](const string_t &blob, ValidityMask &mask, const idx_t idx) {
+		UnaryExecutor::Execute<string_t, double>(
+		    args.data[0], result, args.size(), [&](const string_t &blob) -> optional<double> {
 			    sgl::geometry geom;
 			    lstate.Deserialize(blob, geom);
 
@@ -9053,18 +9036,15 @@ struct PointAccessFunctionBase {
 			    }
 
 			    if (geom.is_empty()) {
-				    mask.SetInvalid(idx);
-				    return 0.0;
+				    return nullopt;
 			    }
 
 			    if (OP::ORDINATE == VertexOrdinate::Z && !geom.has_z()) {
-				    mask.SetInvalid(idx);
-				    return 0.0;
+				    return nullopt;
 			    }
 
 			    if (OP::ORDINATE == VertexOrdinate::M && !geom.has_m()) {
-				    mask.SetInvalid(idx);
-				    return 0.0;
+				    return nullopt;
 			    }
 
 			    const auto vertex_data = geom.get_vertex_array();
@@ -9164,22 +9144,19 @@ struct VertexAggFunctionBase {
 
 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
 		auto &lstate = LocalState::ResetAndGet(state);
-		UnaryExecutor::ExecuteWithNulls<string_t, double>(
-		    args.data[0], result, args.size(), [&](const string_t &blob, ValidityMask &mask, const idx_t idx) {
+		UnaryExecutor::Execute<string_t, double>(
+		    args.data[0], result, args.size(), [&](const string_t &blob) -> optional<double> {
 			    sgl::geometry geom;
 			    lstate.Deserialize(blob, geom);
 
 			    if (geom.is_empty()) {
-				    mask.SetInvalid(idx);
-				    return 0.0;
+				    return nullopt;
 			    }
 			    if (OP::ORDINATE == VertexOrdinate::Z && !geom.has_z()) {
-				    mask.SetInvalid(idx);
-				    return 0.0;
+				    return nullopt;
 			    }
 			    if (OP::ORDINATE == VertexOrdinate::M && !geom.has_m()) {
-				    mask.SetInvalid(idx);
-				    return 0.0;
+				    return nullopt;
 			    }
 
 			    const auto offset = GetOrdinateOffset(geom);
@@ -9234,12 +9211,11 @@ struct VertexAggFunctionBase {
 		const auto axis = OP::ORDINATE == VertexOrdinate::X ? 0 : 1;
 		auto ordinate_data = FlatVector::GetData<double>(line_coords_vec[axis]);
 
-		UnaryExecutor::ExecuteWithNulls<list_entry_t, double>(
-		    line_vec, result, args.size(), [&](const list_entry_t &line, ValidityMask &mask, idx_t idx) {
+		UnaryExecutor::Execute<list_entry_t, double>(
+		    line_vec, result, args.size(), [&](const list_entry_t &line) -> optional<double> {
 			    // Empty line, return NULL
 			    if (line.length == 0) {
-				    mask.SetInvalid(idx);
-				    return 0.0;
+				    return nullopt;
 			    }
 
 			    auto val = AGG::Init();
@@ -9271,14 +9247,13 @@ struct VertexAggFunctionBase {
 		const auto axis = OP::ORDINATE == VertexOrdinate::X ? 0 : 1;
 		auto ordinate_data = FlatVector::GetData<double>(vertex_vec_children[axis]);
 
-		UnaryExecutor::ExecuteWithNulls<list_entry_t, double>(
-		    input, result, count, [&](const list_entry_t &polygon, ValidityMask &mask, idx_t idx) {
+		UnaryExecutor::Execute<list_entry_t, double>(
+		    input, result, count, [&](const list_entry_t &polygon) -> optional<double> {
 			    auto polygon_offset = polygon.offset;
 
 			    // Empty polygon, return NULL
 			    if (polygon.length == 0) {
-				    mask.SetInvalid(idx);
-				    return 0.0;
+				    return nullopt;
 			    }
 
 			    // We only have to check the outer shell
@@ -9288,8 +9263,7 @@ struct VertexAggFunctionBase {
 
 			    // Polygon is invalid. This should never happen but just in case
 			    if (ring_length == 0) {
-				    mask.SetInvalid(idx);
-				    return 0.0;
+				    return nullopt;
 			    }
 
 			    auto val = AGG::Init();

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -5816,7 +5816,7 @@ struct ST_Distance_Sphere {
 			    " * 'SET geometry_always_xy = false' to keep the current behavior and make this warning go away.";
 
 			auto &logger = Logger::Get(context);
-			logger.WriteLog("Spatial", LogLevel::LOG_WARNING, StringUtil::Format(raw_message, func.name.c_str()));
+			logger.WriteLog("Spatial", LogLevel::LOG_WARNING, StringUtil::Format(raw_message, func.GetName().c_str()));
 		}
 
 		return std::move(bind_data);

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -4600,7 +4600,7 @@ struct ST_GeomFromText {
 		if (arguments.empty()) {
 			throw InvalidInputException("ST_GeomFromText requires at least one argument");
 		}
-		const auto &input_type = arguments[0]->return_type;
+		const auto &input_type = arguments[0]->GetReturnType();
 		if (input_type.id() != LogicalTypeId::VARCHAR) {
 			throw InvalidInputException("ST_GeomFromText requires a string argument");
 		}
@@ -4615,8 +4615,8 @@ struct ST_GeomFromText {
 				throw InvalidInputException(
 				    "Non-constant arguments are not supported in ST_GeomFromText optional arguments");
 			}
-			if (arg->alias == "ignore_invalid") {
-				if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+			if (arg->GetAlias() == "ignore_invalid") {
+				if (arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 					throw InvalidInputException("ST_GeomFromText optional argument 'ignore_invalid' must be a boolean");
 				}
 				ignore_invalid = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -179,7 +179,7 @@ struct ST_Affine {
 			sgl::ops::affine_transform(alloc, geom, matrix);
 
 			// Serialize the result
-			FlatVector::GetData<string_t>(result)[out_idx] = lstate.Serialize(result, geom);
+			FlatVector::GetDataMutable<string_t>(result)[out_idx] = lstate.Serialize(result, geom);
 		}
 
 		if (row_count == 1) {
@@ -4801,7 +4801,7 @@ struct ST_GeomFromWKB {
 
 		auto &inner = ListVector::GetEntry(result);
 		const auto lines = ListVector::GetData(result);
-		const auto wkb_data = FlatVector::GetData<string_t>(wkb_blobs);
+		const auto wkb_data = FlatVector::GetDataMutable<string_t>(wkb_blobs);
 
 		idx_t total_size = 0;
 
@@ -4868,7 +4868,7 @@ struct ST_GeomFromWKB {
 		// Set up input data
 		auto &wkb_blobs = args.data[0];
 		wkb_blobs.Flatten(count);
-		auto wkb_data = FlatVector::GetData<string_t>(wkb_blobs);
+		auto wkb_data = FlatVector::GetDataMutable<string_t>(wkb_blobs);
 
 		// Set up output data
 		auto &ring_vec = ListVector::GetEntry(result);
@@ -5589,7 +5589,7 @@ struct ST_LocateBetween {
 		const auto upper_data = UnifiedVectorFormat::GetData<double>(upper_format);
 		const auto offset_data = UnifiedVectorFormat::GetData<double>(offset_format);
 
-		const auto result_data = FlatVector::GetData<string_t>(result);
+		const auto result_data = FlatVector::GetDataMutable<string_t>(result);
 
 		for (idx_t out_idx = 0; out_idx < row_count; out_idx++) {
 			const auto geom_idx = geom_format.sel->get_index(out_idx);
@@ -6213,7 +6213,7 @@ struct ST_InteriorRingN {
 		// To inspect n per-row, extract unified format for n (it might be constant)
 		UnifiedVectorFormat n_format;
 		n_vec.ToUnifiedFormat(count, n_format);
-		auto n_data = FlatVector::GetData<int64_t>(n_vec);
+		auto n_data = FlatVector::GetDataMutable<int64_t>(n_vec);
 
 		for (idx_t i = 0; i < count; i++) {
 			auto row_idx = poly_format.sel->get_index(i);

--- a/src/spatial/modules/main/spatial_functions_table.cpp
+++ b/src/spatial/modules/main/spatial_functions_table.cpp
@@ -133,7 +133,7 @@ struct ST_GeneratePoints {
 		set.AddFunction(generate_points);
 
 		// Overload with seed
-		generate_points.arguments = {GeoTypes::BOX_2D(), LogicalType::BIGINT, LogicalType::BIGINT};
+		generate_points.GetArguments() = {GeoTypes::BOX_2D(), LogicalType::BIGINT, LogicalType::BIGINT};
 		set.AddFunction(generate_points);
 		loader.RegisterFunction(set);
 

--- a/src/spatial/modules/main/spatial_functions_table.cpp
+++ b/src/spatial/modules/main/spatial_functions_table.cpp
@@ -96,6 +96,7 @@ struct ST_GeneratePoints {
 
 			state.current_idx++;
 		}
+		FlatVector::SetSize(output.data[0], count_t(chunk_size));
 		output.SetCardinality(chunk_size);
 	}
 

--- a/src/spatial/modules/main/spatial_functions_table.cpp
+++ b/src/spatial/modules/main/spatial_functions_table.cpp
@@ -85,8 +85,8 @@ struct ST_GeneratePoints {
 		auto &state = data_p.global_state->Cast<GeneratePointsState>();
 
 		auto &point_vec = StructVector::GetEntries(output.data[0]);
-		const auto &x_data = FlatVector::GetData<double>(point_vec[0]);
-		const auto &y_data = FlatVector::GetData<double>(point_vec[1]);
+		auto x_data = FlatVector::GetDataMutable<double>(point_vec[0]);
+		auto y_data = FlatVector::GetDataMutable<double>(point_vec[1]);
 
 		const auto chunk_size = MinValue<idx_t>(STANDARD_VECTOR_SIZE, bind_data.count - state.current_idx);
 		for (idx_t i = 0; i < chunk_size; i++) {

--- a/src/spatial/modules/mvt/mvt_module.cpp
+++ b/src/spatial/modules/mvt/mvt_module.cpp
@@ -74,7 +74,7 @@ struct ST_TileEnvelope {
 		auto &lstate = LocalState::ResetAndGet(state);
 
 		TernaryExecutor::Execute<int32_t, int32_t, int32_t, string_t>(
-		    args.data[0], args.data[1], args.data[2], result, args.size(),
+		    args.data[0], args.data[1], args.data[2], result,
 		    [&](int32_t tile_zoom, int32_t tile_x, int32_t tile_y) {
 			    validate_tile_zoom_argument(tile_zoom);
 			    uint32_t zoom_extent = 1u << tile_zoom;

--- a/src/spatial/modules/mvt/mvt_module.cpp
+++ b/src/spatial/modules/mvt/mvt_module.cpp
@@ -1266,7 +1266,7 @@ struct ST_AsMVT {
 			func.SetFunction(agg);
 			for (auto &arg_type : optional_args) {
 				// Register all the variants with optional arguments
-				agg.arguments.push_back(arg_type);
+				agg.GetArguments().push_back(arg_type);
 				func.SetFunction(agg);
 			}
 

--- a/src/spatial/modules/mvt/mvt_module.cpp
+++ b/src/spatial/modules/mvt/mvt_module.cpp
@@ -1154,7 +1154,7 @@ struct ST_AsMVT {
 		source_vec.ToUnifiedFormat(count, source_format);
 
 		const auto source_ptr = UnifiedVectorFormat::GetData<State *>(source_format);
-		const auto target_ptr = FlatVector::GetData<State *>(target_vec);
+		const auto target_ptr = FlatVector::GetDataMutable<State *>(target_vec);
 
 		for (idx_t row_idx = 0; row_idx < count; row_idx++) {
 			auto &source = *source_ptr[source_format.sel->get_index(row_idx)];
@@ -1193,7 +1193,7 @@ struct ST_AsMVT {
 			state.layer.Finalize(bdata.extent, bdata.tag_names, bdata.layer_name, buffer, tag_dict);
 
 			// Now we have the layer buffer, we can write it to the result vector
-			const auto result_data = FlatVector::GetData<string_t>(result);
+			const auto result_data = FlatVector::GetDataMutable<string_t>(result);
 			result_data[out_idx] = StringVector::AddStringOrBlob(result, buffer.data(), buffer.size());
 		}
 	}

--- a/src/spatial/modules/mvt/mvt_module.cpp
+++ b/src/spatial/modules/mvt/mvt_module.cpp
@@ -824,8 +824,12 @@ struct ST_AsMVT {
 		}
 	};
 
-	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
-	                                     vector<unique_ptr<Expression>> &arguments) {
+	static unique_ptr<FunctionData> Bind(BindAggregateFunctionInput &input) {
+		auto &context = input.GetClientContext();
+		auto &arguments = input.GetArguments();
+		auto &function = input.GetBoundFunction();
+
+
 		auto result = make_uniq<BindData>();
 
 		// Figure part of the row is the geometry column

--- a/src/spatial/modules/mvt/mvt_module.cpp
+++ b/src/spatial/modules/mvt/mvt_module.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/aggregate_function.hpp"
 #include "spatial/geometry/geometry_serialization.hpp"
 #include "spatial/geometry/sgl.hpp"
 #include "spatial/spatial_types.hpp"
@@ -1009,11 +1010,11 @@ struct ST_AsMVT {
 		MVTLayer layer;
 	};
 
-	static idx_t StateSize(const AggregateFunction &) {
+	static idx_t StateSize(const BoundAggregateFunction &) {
 		return sizeof(State);
 	}
 
-	static void Initialize(const AggregateFunction &, data_ptr_t state_mem) {
+	static void Initialize(const BoundAggregateFunction &, data_ptr_t state_mem) {
 		new (state_mem) State();
 	}
 
@@ -1266,7 +1267,7 @@ struct ST_AsMVT {
 			func.SetFunction(agg);
 			for (auto &arg_type : optional_args) {
 				// Register all the variants with optional arguments
-				agg.GetArguments().push_back(arg_type);
+				agg.GetSignature().AddParameter(arg_type);
 				func.SetFunction(agg);
 			}
 

--- a/src/spatial/modules/mvt/mvt_module.cpp
+++ b/src/spatial/modules/mvt/mvt_module.cpp
@@ -833,7 +833,7 @@ struct ST_AsMVT {
 		auto result = make_uniq<BindData>();
 
 		// Figure part of the row is the geometry column
-		const auto &row_type = arguments[0]->return_type;
+		const auto &row_type = arguments[0]->GetReturnType();
 		if (row_type.id() != LogicalTypeId::STRUCT) {
 			throw InvalidInputException("ST_AsMVT: first argument must be a STRUCT (i.e. a row type)");
 		}

--- a/src/spatial/modules/osm/osm_module.cpp
+++ b/src/spatial/modules/osm/osm_module.cpp
@@ -44,7 +44,7 @@ unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &in
 	// Create an enum type for all osm kinds
 	vector<string_t> enum_values = {"node", "way", "relation", "changeset"};
 	auto varchar_vector = Vector(LogicalType::VARCHAR, enum_values.size());
-	auto varchar_data = FlatVector::GetData<string_t>(varchar_vector);
+	auto varchar_data = FlatVector::GetDataMutable<string_t>(varchar_vector);
 	for (idx_t i = 0; i < enum_values.size(); i++) {
 		auto str = enum_values[i];
 		varchar_data[i] = str.IsInlined() ? str : StringVector::AddString(varchar_vector, str);
@@ -75,7 +75,7 @@ unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &in
 	// Create an enum type for the member kind
 	vector<string_t> member_enum_values = {"node", "way", "relation"};
 	auto member_varchar_vector = Vector(LogicalType::VARCHAR, member_enum_values.size());
-	auto member_varchar_data = FlatVector::GetData<string_t>(member_varchar_vector);
+	auto member_varchar_data = FlatVector::GetDataMutable<string_t>(member_varchar_vector);
 	for (idx_t i = 0; i < member_enum_values.size(); i++) {
 		auto str = member_enum_values[i];
 		member_varchar_data[i] = str.IsInlined() ? str : StringVector::AddString(member_varchar_vector, str);
@@ -394,8 +394,8 @@ struct LocalState final : LocalTableFunctionState {
 			switch (node.tag()) {
 			case 1: { // ID
 				auto id = node.get_int64();
-				FlatVector::GetData<uint8_t>(output.data[0])[index] = 0;
-				FlatVector::GetData<int64_t>(output.data[1])[index] = id;
+				FlatVector::GetDataMutable<uint8_t>(output.data[0])[index] = 0;
+				FlatVector::GetDataMutable<int64_t>(output.data[1])[index] = id;
 			} break;
 			case 2: { // Tag Keys
 				key_iter = node.get_packed_uint32();
@@ -405,11 +405,11 @@ struct LocalState final : LocalTableFunctionState {
 			} break;
 			case 8: { // Lat
 				auto lat = node.get_sint64();
-				FlatVector::GetData<double>(output.data[4])[index] = 0.000000001 * (lat_offset + (granularity * lat));
+				FlatVector::GetDataMutable<double>(output.data[4])[index] = 0.000000001 * (lat_offset + (granularity * lat));
 			} break;
 			case 9: { // Lon
 				auto lon = node.get_sint64();
-				FlatVector::GetData<double>(output.data[5])[index] = 0.000000001 * (lon_offset + (granularity * lon));
+				FlatVector::GetDataMutable<double>(output.data[5])[index] = 0.000000001 * (lon_offset + (granularity * lon));
 			} break;
 			default:
 				node.skip();
@@ -433,9 +433,9 @@ struct LocalState final : LocalTableFunctionState {
 			auto keys = key_iter.begin();
 			auto vals = val_iter.begin();
 			for (idx_t i = tag_entry.offset; i < tag_entry.offset + tag_count; i++) {
-				FlatVector::GetData<string_t>(key_vector)[i] =
+				FlatVector::GetDataMutable<string_t>(key_vector)[i] =
 				    StringVector::AddString(key_vector, string_table[*keys++]);
-				FlatVector::GetData<string_t>(value_vector)[i] =
+				FlatVector::GetDataMutable<string_t>(value_vector)[i] =
 				    StringVector::AddString(value_vector, string_table[*vals++]);
 			}
 		} else {
@@ -516,8 +516,8 @@ struct LocalState final : LocalTableFunctionState {
 			switch (way.tag()) {
 			case 1: { // ID
 				auto id = way.get_int64();
-				FlatVector::GetData<uint8_t>(output.data[0])[index] = 1;
-				FlatVector::GetData<int64_t>(output.data[1])[index] = id;
+				FlatVector::GetDataMutable<uint8_t>(output.data[0])[index] = 1;
+				FlatVector::GetDataMutable<int64_t>(output.data[1])[index] = id;
 				FlatVector::SetNull(output.data[4], index, true);
 				FlatVector::SetNull(output.data[5], index, true);
 				FlatVector::SetNull(output.data[6], index, true);
@@ -552,9 +552,9 @@ struct LocalState final : LocalTableFunctionState {
 			auto keys = key_iter.begin();
 			auto vals = val_iter.begin();
 			for (idx_t i = tag_entry.offset; i < tag_entry.offset + tag_count; i++) {
-				FlatVector::GetData<string_t>(key_vector)[i] =
+				FlatVector::GetDataMutable<string_t>(key_vector)[i] =
 				    StringVector::AddString(key_vector, string_table[*keys++]);
-				FlatVector::GetData<string_t>(value_vector)[i] =
+				FlatVector::GetDataMutable<string_t>(value_vector)[i] =
 				    StringVector::AddString(value_vector, string_table[*vals++]);
 			}
 		} else {
@@ -571,7 +571,7 @@ struct LocalState final : LocalTableFunctionState {
 			ref_entry.offset = total_refs;
 			ref_entry.length = ref_count;
 
-			auto ref_data = FlatVector::GetData<int64_t>(ref_vector);
+			auto ref_data = FlatVector::GetDataMutable<int64_t>(ref_vector);
 
 			int64_t last_ref = 0;
 			for (auto ref : ref_iter) {
@@ -598,8 +598,8 @@ struct LocalState final : LocalTableFunctionState {
 			switch (relation.tag()) {
 			case 1: { // ID
 				auto id = relation.get_int64();
-				FlatVector::GetData<uint8_t>(output.data[0])[index] = 2;
-				FlatVector::GetData<int64_t>(output.data[1])[index] = id;
+				FlatVector::GetDataMutable<uint8_t>(output.data[0])[index] = 2;
+				FlatVector::GetDataMutable<int64_t>(output.data[1])[index] = id;
 				FlatVector::SetNull(output.data[4], index, true);
 				FlatVector::SetNull(output.data[5], index, true);
 			} break;
@@ -641,9 +641,9 @@ struct LocalState final : LocalTableFunctionState {
 			auto keys = key_iter.begin();
 			auto vals = val_iter.begin();
 			for (idx_t i = tag_entry.offset; i < tag_entry.offset + tag_count; i++) {
-				FlatVector::GetData<string_t>(key_vector)[i] =
+				FlatVector::GetDataMutable<string_t>(key_vector)[i] =
 				    StringVector::AddString(key_vector, string_table[*keys++]);
-				FlatVector::GetData<string_t>(value_vector)[i] =
+				FlatVector::GetDataMutable<string_t>(value_vector)[i] =
 				    StringVector::AddString(value_vector, string_table[*vals++]);
 			}
 		} else {
@@ -668,7 +668,7 @@ struct LocalState final : LocalTableFunctionState {
 				if (role_str.empty()) {
 					FlatVector::SetNull(role_vector, i, true);
 				} else {
-					FlatVector::GetData<string_t>(role_vector)[i] = StringVector::AddString(role_vector, role_str);
+					FlatVector::GetDataMutable<string_t>(role_vector)[i] = StringVector::AddString(role_vector, role_str);
 				}
 			}
 		} else {
@@ -687,7 +687,7 @@ struct LocalState final : LocalTableFunctionState {
 			ref_entry.offset = total_refs;
 			ref_entry.length = ref_count;
 
-			auto ref_data = FlatVector::GetData<int64_t>(ref_vector);
+			auto ref_data = FlatVector::GetDataMutable<int64_t>(ref_vector);
 
 			int64_t last_ref = 0;
 			for (auto ref : ref_iter) {
@@ -710,7 +710,7 @@ struct LocalState final : LocalTableFunctionState {
 			type_entry.offset = total_types;
 			type_entry.length = type_count;
 
-			auto type_data = FlatVector::GetData<uint8_t>(type_vector);
+			auto type_data = FlatVector::GetDataMutable<uint8_t>(type_vector);
 			for (auto type : type_iter) {
 				type_data[total_types++] = (uint8_t)type;
 			}
@@ -727,10 +727,10 @@ struct LocalState final : LocalTableFunctionState {
 		auto nodes_to_write = capacity - index;
 		auto nodes_to_read = std::min(nodes_to_write, dense_node_ids.size() - dense_node_index);
 
-		auto kind_data = FlatVector::GetData<uint8_t>(output.data[0]);
-		auto id_data = FlatVector::GetData<int64_t>(output.data[1]);
-		auto lat_data = FlatVector::GetData<double>(output.data[4]);
-		auto lon_data = FlatVector::GetData<double>(output.data[5]);
+		auto kind_data = FlatVector::GetDataMutable<uint8_t>(output.data[0]);
+		auto id_data = FlatVector::GetDataMutable<int64_t>(output.data[1]);
+		auto lat_data = FlatVector::GetDataMutable<double>(output.data[4]);
+		auto lon_data = FlatVector::GetDataMutable<double>(output.data[5]);
 
 		for (idx_t i = 0; i < nodes_to_read; i++) {
 			auto id = dense_node_ids[dense_node_index];
@@ -766,9 +766,9 @@ struct LocalState final : LocalTableFunctionState {
 						auto key_id = dense_node_tags[t];
 						auto val_id = dense_node_tags[t + 1];
 
-						FlatVector::GetData<string_t>(key_vector)[r] =
+						FlatVector::GetDataMutable<string_t>(key_vector)[r] =
 						    StringVector::AddString(key_vector, string_table[key_id]);
-						FlatVector::GetData<string_t>(value_vector)[r] =
+						FlatVector::GetDataMutable<string_t>(value_vector)[r] =
 						    StringVector::AddString(value_vector, string_table[val_id]);
 
 						t += 2;

--- a/src/spatial/modules/osm/osm_module.cpp
+++ b/src/spatial/modules/osm/osm_module.cpp
@@ -422,7 +422,7 @@ struct LocalState final : LocalTableFunctionState {
 			auto total_tags = ListVector::GetListSize(output.data[2]);
 			ListVector::Reserve(output.data[2], total_tags + tag_count);
 			ListVector::SetListSize(output.data[2], total_tags + tag_count);
-			auto &tag_entry = ListVector::GetData(output.data[2])[index];
+			auto &tag_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[2])[index];
 
 			tag_entry.offset = total_tags;
 			tag_entry.length = tag_count;
@@ -541,7 +541,7 @@ struct LocalState final : LocalTableFunctionState {
 			auto total_tags = ListVector::GetListSize(output.data[2]);
 			ListVector::Reserve(output.data[2], total_tags + tag_count);
 			ListVector::SetListSize(output.data[2], total_tags + tag_count);
-			auto &tag_entry = ListVector::GetData(output.data[2])[index];
+			auto &tag_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[2])[index];
 
 			tag_entry.offset = total_tags;
 			tag_entry.length = tag_count;
@@ -566,7 +566,7 @@ struct LocalState final : LocalTableFunctionState {
 			auto total_refs = ListVector::GetListSize(output.data[3]);
 			ListVector::Reserve(output.data[3], total_refs + ref_count);
 			ListVector::SetListSize(output.data[3], total_refs + ref_count);
-			auto &ref_entry = ListVector::GetData(output.data[3])[index];
+			auto &ref_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[3])[index];
 			auto &ref_vector = ListVector::GetEntry(output.data[3]);
 			ref_entry.offset = total_refs;
 			ref_entry.length = ref_count;
@@ -630,7 +630,7 @@ struct LocalState final : LocalTableFunctionState {
 			auto total_tags = ListVector::GetListSize(output.data[2]);
 			ListVector::Reserve(output.data[2], total_tags + tag_count);
 			ListVector::SetListSize(output.data[2], total_tags + tag_count);
-			auto &tag_entry = ListVector::GetData(output.data[2])[index];
+			auto &tag_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[2])[index];
 
 			tag_entry.offset = total_tags;
 			tag_entry.length = tag_count;
@@ -657,7 +657,7 @@ struct LocalState final : LocalTableFunctionState {
 			auto total_roles = ListVector::GetListSize(output.data[6]);
 			ListVector::Reserve(output.data[6], total_roles + role_count);
 			ListVector::SetListSize(output.data[6], total_roles + role_count);
-			auto &role_entry = ListVector::GetData(output.data[6])[index];
+			auto &role_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[6])[index];
 			auto &role_vector = ListVector::GetEntry(output.data[6]);
 			role_entry.offset = total_roles;
 			role_entry.length = role_count;
@@ -682,7 +682,7 @@ struct LocalState final : LocalTableFunctionState {
 			auto total_refs = ListVector::GetListSize(output.data[3]);
 			ListVector::Reserve(output.data[3], total_refs + ref_count);
 			ListVector::SetListSize(output.data[3], total_refs + ref_count);
-			auto &ref_entry = ListVector::GetData(output.data[3])[index];
+			auto &ref_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[3])[index];
 			auto &ref_vector = ListVector::GetEntry(output.data[3]);
 			ref_entry.offset = total_refs;
 			ref_entry.length = ref_count;
@@ -705,7 +705,7 @@ struct LocalState final : LocalTableFunctionState {
 			auto total_types = ListVector::GetListSize(output.data[7]);
 			ListVector::Reserve(output.data[7], total_types + type_count);
 			ListVector::SetListSize(output.data[7], total_types + type_count);
-			auto &type_entry = ListVector::GetData(output.data[7])[index];
+			auto &type_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[7])[index];
 			auto &type_vector = ListVector::GetEntry(output.data[7]);
 			type_entry.offset = total_types;
 			type_entry.length = type_count;
@@ -751,7 +751,7 @@ struct LocalState final : LocalTableFunctionState {
 					auto total_tags = ListVector::GetListSize(output.data[2]);
 					ListVector::Reserve(output.data[2], total_tags + tag_count);
 					ListVector::SetListSize(output.data[2], total_tags + tag_count);
-					auto &tag_entry = ListVector::GetData(output.data[2])[index];
+					auto &tag_entry = FlatVector::GetDataMutable<list_entry_t>(output.data[2])[index];
 
 					tag_entry.offset = total_tags;
 					tag_entry.length = tag_count;

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -301,7 +301,7 @@ struct ST_Transform {
 		}
 
 		// Set return types
-		func.arguments[0] = geo_arg->return_type;
+		func.GetArguments()[0] = geo_arg->return_type;
 		func.SetReturnType(LogicalType::GEOMETRY(*result_crs));
 
 		// Check if we need to warn for this

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -1469,7 +1469,7 @@ struct DuckDB_Proj_Version {
 		PJ_INFO pj_info = proj_info();
 		string_t version(pj_info.version);
 		auto val = Value(version);
-		result.Reference(val);
+		result.Reference(val, count_t(args.size()));
 	}
 
 	static constexpr auto DESCRIPTION = R"(
@@ -1510,7 +1510,7 @@ struct DuckDB_Proj_Compiled_Version {
 		D_ASSERT(args.ColumnCount() == 0);
 		string_t version(pj_release);
 		auto val = Value(version);
-		result.Reference(val);
+		result.Reference(val, count_t(args.size()));
 	}
 
 	static constexpr auto DESCRIPTION = R"(

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -297,7 +297,7 @@ struct ST_Transform {
 
 		// Set return types
 		func.arguments[0] = geo_arg->return_type;
-		func.return_type = LogicalType::GEOMETRY(*result_crs);
+		func.SetReturnType(LogicalType::GEOMETRY(*result_crs));
 
 		// Check if we need to warn for this
 		if (!explicit_normalize) {

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -223,14 +223,14 @@ struct ST_Transform {
 		}
 
 		static void Serialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
-		                      const ScalarFunction &function) {
+		                      const BoundScalarFunction &function) {
 			auto &bind_data = bind_data_p->Cast<TypedBindData>();
 			serializer.WritePropertyWithDefault(100, "normalize", bind_data.normalize);
 			serializer.WritePropertyWithDefault(101, "source", bind_data.source_crs);
 			serializer.WritePropertyWithDefault(102, "target", bind_data.target_crs);
 		}
 
-		static unique_ptr<FunctionData> Deserialize(Deserializer &deserializer, ScalarFunction &function) {
+		static unique_ptr<FunctionData> Deserialize(Deserializer &deserializer, BoundScalarFunction &function) {
 			auto result = make_uniq<TypedBindData>();
 			deserializer.ReadPropertyWithDefault(100, "normalize", result->normalize);
 			deserializer.ReadPropertyWithDefault(101, "source", result->source_crs);

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -470,7 +470,7 @@ struct ST_Transform {
 		const auto &info = func_expr.bind_info->Cast<BindData>();
 
 		TernaryExecutor::Execute<string_t, string_t, string_t, string_t>(
-		    args.data[0], args.data[1], args.data[2], result, args.size(),
+		    args.data[0], args.data[1], args.data[2], result,
 		    [&](const string_t &blob, const string_t &source, const string_t &target) {
 			    const auto source_str = source.GetString();
 			    const auto target_str = target.GetString();

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -251,32 +251,32 @@ struct ST_Transform {
 
 		// Get CRS from source geometry
 		const auto &geo_arg = args[0];
-		if (!GeoType::HasCRS(geo_arg->return_type)) {
-			throw BinderException(geo_arg->query_location, "Source geometry must have a coordinate reference system");
+		if (!GeoType::HasCRS(geo_arg->GetReturnType())) {
+			throw BinderException(geo_arg->GetQueryLocation(), "Source geometry must have a coordinate reference system");
 		}
-		result->source_crs = GeoType::GetCRS(geo_arg->return_type).GetDefinition();
+		result->source_crs = GeoType::GetCRS(geo_arg->GetReturnType()).GetDefinition();
 		if (result->source_crs.empty()) {
-			throw BinderException(geo_arg->query_location, "Source geometry must have a coordinate reference system");
+			throw BinderException(geo_arg->GetQueryLocation(), "Source geometry must have a coordinate reference system");
 		}
 
 		// Constant-fold target_crs
 		const auto &crs_arg = args[1];
 		if (crs_arg->HasParameter()) {
-			throw BinderException(crs_arg->query_location, "The 'target_crs' parameter must be a constant");
+			throw BinderException(crs_arg->GetQueryLocation(), "The 'target_crs' parameter must be a constant");
 		}
 		if (!crs_arg->IsFoldable()) {
-			throw BinderException(crs_arg->query_location, "The 'target_crs' parameter must be a constant");
+			throw BinderException(crs_arg->GetQueryLocation(), "The 'target_crs' parameter must be a constant");
 		}
-		if (crs_arg->return_type.id() != LogicalTypeId::VARCHAR) {
-			throw BinderException(crs_arg->query_location, "The 'target_crs' parameter must be a string");
+		if (crs_arg->GetReturnType().id() != LogicalTypeId::VARCHAR) {
+			throw BinderException(crs_arg->GetQueryLocation(), "The 'target_crs' parameter must be a string");
 		}
 		result->target_crs = StringValue::Get(ExpressionExecutor::EvaluateScalar(ctx, *crs_arg));
 		if (result->target_crs.empty()) {
-			throw BinderException(crs_arg->query_location, "The 'target_crs' parameter cannot be empty");
+			throw BinderException(crs_arg->GetQueryLocation(), "The 'target_crs' parameter cannot be empty");
 		}
 		const auto result_crs = CoordinateReferenceSystem::TryIdentify(ctx, result->target_crs);
 		if (!result_crs) {
-			throw BinderException(crs_arg->query_location,
+			throw BinderException(crs_arg->GetQueryLocation(),
 			                      "The 'target_crs' parameter '%s' is not a recognized coordinate reference system",
 			                      result->target_crs);
 		}
@@ -286,13 +286,13 @@ struct ST_Transform {
 		if (args.size() == 3) {
 			const auto &xy_arg = args[2];
 			if (xy_arg->HasParameter()) {
-				throw BinderException(xy_arg->query_location, "The 'always_xy' parameter must be a constant");
+				throw BinderException(xy_arg->GetQueryLocation(), "The 'always_xy' parameter must be a constant");
 			}
 			if (!xy_arg->IsFoldable()) {
-				throw BinderException(xy_arg->query_location, "The 'always_xy' parameter must be a constant");
+				throw BinderException(xy_arg->GetQueryLocation(), "The 'always_xy' parameter must be a constant");
 			}
-			if (xy_arg->return_type.id() != LogicalTypeId::BOOLEAN) {
-				throw BinderException(xy_arg->query_location, "The 'always_xy' parameter must be a boolean");
+			if (xy_arg->GetReturnType().id() != LogicalTypeId::BOOLEAN) {
+				throw BinderException(xy_arg->GetQueryLocation(), "The 'always_xy' parameter must be a boolean");
 			}
 			result->normalize = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(ctx, *xy_arg));
 			explicit_normalize = true;
@@ -301,7 +301,7 @@ struct ST_Transform {
 		}
 
 		// Set return types
-		func.GetArguments()[0] = geo_arg->return_type;
+		func.GetArguments()[0] = geo_arg->GetReturnType();
 		func.SetReturnType(LogicalType::GEOMETRY(*result_crs));
 
 		// Check if we need to warn for this

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -163,7 +163,10 @@ struct ST_Transform {
 		}
 	};
 
-	static unique_ptr<FunctionData> Bind(ClientContext &ctx, ScalarFunction &, vector<unique_ptr<Expression>> &args) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto &ctx = input.GetClientContext();
+		auto &args = input.GetArguments();
+
 		auto result = make_uniq<BindData>();
 
 		// If always_xy is set, then always normalize
@@ -239,8 +242,10 @@ struct ST_Transform {
 		}
 	};
 
-	static unique_ptr<FunctionData> BindTyped(ClientContext &ctx, ScalarFunction &func,
-	                                          vector<unique_ptr<Expression>> &args) {
+	static unique_ptr<FunctionData> BindTyped(BindScalarFunctionInput &input) {
+		auto &ctx = input.GetClientContext();
+		auto &func = input.GetBoundFunction();
+		auto &args = input.GetArguments();
 
 		auto result = make_uniq<TypedBindData>();
 
@@ -725,8 +730,10 @@ struct GeodesicBindData final : FunctionData {
 		return always_xy == data.always_xy;
 	}
 
-	static unique_ptr<FunctionData> Bind(ClientContext &ctx, ScalarFunction &func,
-	                                     vector<unique_ptr<Expression>> &args) {
+	static unique_ptr<FunctionData> Bind(BindScalarFunctionInput &input) {
+		auto &ctx = input.GetClientContext();
+		auto &func = input.GetBoundFunction();
+
 		auto result = make_uniq<GeodesicBindData>();
 
 		bool is_set = false;
@@ -797,7 +804,7 @@ struct GeodesicLocalState final : FunctionLocalState {
 
 struct ST_Area_Spheroid {
 
-	//------------------------------------------------------------------------------------------------------------------
+	//--------------------------------------------------------------------------------------o----------------------------
 	// Execute (POLYGON_2D)
 	//------------------------------------------------------------------------------------------------------------------
 

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -750,7 +750,7 @@ struct GeodesicBindData final : FunctionData {
 			    " * 'SET geometry_always_xy = false' to keep the current behavior and make this warning go away.";
 
 			auto &logger = Logger::Get(ctx);
-			logger.WriteLog("Spatial", LogLevel::LOG_WARNING, StringUtil::Format(raw_message, func.name.c_str()));
+			logger.WriteLog("Spatial", LogLevel::LOG_WARNING, StringUtil::Format(raw_message, func.GetName().c_str()));
 		}
 
 		return std::move(result);

--- a/src/spatial/modules/shapefile/shapefile_module.cpp
+++ b/src/spatial/modules/shapefile/shapefile_module.cpp
@@ -653,7 +653,7 @@ struct ST_ReadSHP {
 			blob.Finalize();
 
 			// Set the blob in the result vector
-			FlatVector::GetData<string_t>(result)[result_idx] = blob;
+			FlatVector::GetDataMutable<string_t>(result)[result_idx] = blob;
 		}
 	}
 
@@ -661,7 +661,7 @@ struct ST_ReadSHP {
 	                                  ArenaAllocator &arena, int geom_type) {
 		switch (geom_type) {
 		case SHPT_NULL:
-			FlatVector::Validity(result).SetAllInvalid(count);
+			FlatVector::ValidityMutable(result).SetAllInvalid(count);
 			break;
 		case SHPT_POINT:
 			ConvertGeomLoop<ConvertPoint>(result, record_start, count, shp_handle, arena);
@@ -745,7 +745,7 @@ struct ST_ReadSHP {
 			if (DBFIsAttributeNULL(dbf_handle, record_idx, field_idx)) {
 				FlatVector::SetNull(result, row_idx, true);
 			} else {
-				FlatVector::GetData<typename OP::TYPE>(result)[row_idx] =
+				FlatVector::GetDataMutable<typename OP::TYPE>(result)[row_idx] =
 				    OP::Convert(result, dbf_handle, record_idx, field_idx);
 			}
 			record_idx++;
@@ -775,7 +775,7 @@ struct ST_ReadSHP {
 					throw InvalidInputException("Could not decode VARCHAR field as valid UTF-8, try passing "
 					                            "encoding='blob' to skip decoding of string attributes");
 				}
-				FlatVector::GetData<string_t>(result)[row_idx] = result_str;
+				FlatVector::GetDataMutable<string_t>(result)[row_idx] = result_str;
 			}
 			record_idx++;
 		}
@@ -961,7 +961,7 @@ struct Shapefile_Meta {
 
 		auto shape_type_count = sizeof(shape_type_map) / sizeof(ShapeTypeEntry);
 		auto varchar_vector = Vector(LogicalType::VARCHAR, shape_type_count);
-		auto varchar_data = FlatVector::GetData<string_t>(varchar_vector);
+		auto varchar_data = FlatVector::GetDataMutable<string_t>(varchar_vector);
 		for (idx_t i = 0; i < shape_type_count; i++) {
 			auto str = string_t(shape_type_map[i].shp_name);
 			varchar_data[i] = str.IsInlined() ? str : StringVector::AddString(varchar_vector, str);

--- a/src/spatial/modules/shapefile/shapefile_module.cpp
+++ b/src/spatial/modules/shapefile/shapefile_module.cpp
@@ -896,6 +896,7 @@ struct ST_ReadSHP {
 		read_func.table_scan_progress = GetProgress;
 		read_func.cardinality = GetCardinality;
 		read_func.projection_pushdown = true;
+		read_func.parallelism = TableFunctionParallelism::SEQUENTIAL;
 		loader.RegisterFunction(read_func);
 
 		InsertionOrderPreservingMap<string> tags;

--- a/src/spatial/modules/shapefile/shapefile_module.cpp
+++ b/src/spatial/modules/shapefile/shapefile_module.cpp
@@ -1003,17 +1003,17 @@ struct Shapefile_Meta {
 		auto &fs = FileSystem::GetFileSystem(context);
 
 		auto &file_name_vector = output.data[0];
-		auto file_name_data = FlatVector::GetData<string_t>(file_name_vector);
+		auto file_name_data = FlatVector::GetDataMutable<string_t>(file_name_vector);
 		auto &shape_type_vector = output.data[1];
-		auto shape_type_data = FlatVector::GetData<uint8_t>(shape_type_vector);
+		auto shape_type_data = FlatVector::GetDataMutable<uint8_t>(shape_type_vector);
 		auto &bounds_vector = output.data[2];
 		auto &bounds_vector_children = StructVector::GetEntries(bounds_vector);
-		auto minx_data = FlatVector::GetData<double>(bounds_vector_children[0]);
-		auto miny_data = FlatVector::GetData<double>(bounds_vector_children[1]);
-		auto maxx_data = FlatVector::GetData<double>(bounds_vector_children[2]);
-		auto maxy_data = FlatVector::GetData<double>(bounds_vector_children[3]);
+		auto minx_data = FlatVector::GetDataMutable<double>(bounds_vector_children[0]);
+		auto miny_data = FlatVector::GetDataMutable<double>(bounds_vector_children[1]);
+		auto maxx_data = FlatVector::GetDataMutable<double>(bounds_vector_children[2]);
+		auto maxy_data = FlatVector::GetDataMutable<double>(bounds_vector_children[3]);
 		auto &record_count_vector = output.data[3];
-		auto record_count_data = FlatVector::GetData<int32_t>(record_count_vector);
+		auto record_count_data = FlatVector::GetDataMutable<int32_t>(record_count_vector);
 
 		auto output_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, bind_data.files.size() - state.current_file_idx);
 

--- a/src/spatial/modules/shapefile/shapefile_module.cpp
+++ b/src/spatial/modules/shapefile/shapefile_module.cpp
@@ -844,7 +844,7 @@ struct ST_ReadSHP {
 		gstate.shape_idx += output_size;
 
 		// Set the cardinality of the output
-		output.SetCardinality(output_size);
+		output.SetChildCardinality(output_size);
 	}
 
 	//------------------------------------------------------------------------------------------------------------------
@@ -1044,7 +1044,11 @@ struct Shapefile_Meta {
 		}
 
 		state.current_file_idx += output_count;
-		output.SetCardinality(output_count);
+		FlatVector::SetSize(bounds_vector_children[0], count_t(output_count));
+		FlatVector::SetSize(bounds_vector_children[1], count_t(output_count));
+		FlatVector::SetSize(bounds_vector_children[2], count_t(output_count));
+		FlatVector::SetSize(bounds_vector_children[3], count_t(output_count));
+		output.SetChildCardinality(output_count);
 	}
 
 	static double GetProgress(ClientContext &context, const FunctionData *bind_data,

--- a/src/spatial/modules/wkb/wkb_module.cpp
+++ b/src/spatial/modules/wkb/wkb_module.cpp
@@ -17,7 +17,7 @@ struct WKBTypes {
 	}
 
 	static bool ToWKBCast(Vector &source, Vector &result, idx_t count, CastParameters &) {
-		Geometry::ToBinary(source, result, count);
+		Geometry::ToBinary(source, result);
 		return true;
 	}
 

--- a/src/spatial/operators/spatial_join_optimizer.cpp
+++ b/src/spatial/operators/spatial_join_optimizer.cpp
@@ -56,7 +56,7 @@ static bool HasInversePredicate(const string &func_name) {
 static unique_ptr<Expression> GetInversePredicate(ClientContext &context, unique_ptr<Expression> expr) {
 	auto &func = expr->Cast<BoundFunctionExpression>();
 
-	const auto it = spatial_predicate_inverse_map.find(func.function.name);
+	const auto it = spatial_predicate_inverse_map.find(func.function.GetName());
 	D_ASSERT(it != spatial_predicate_inverse_map.end());
 
 	// Swap the arguments
@@ -70,11 +70,11 @@ static unique_ptr<Expression> GetInversePredicate(ClientContext &context, unique
 	// Get the function from the catalog
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, it->second);
-	auto inverse_func =
+	const auto &inverse_func =
 	    entry.functions.GetFunctionByArguments(context, {func.children[0]->GetReturnType(), func.children[1]->GetReturnType()});
 
-	return make_uniq_base<Expression, BoundFunctionExpression>(func.GetReturnType(), inverse_func, std::move(func.children),
-	                                                           nullptr, func.is_operator);
+	auto func_expr = inverse_func.Bind(context, std::move(func.children));
+	return std::move(func_expr);
 }
 
 static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const unordered_set<TableIndex> &left_bindings,
@@ -104,7 +104,7 @@ static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const uno
 	}
 
 	// The function must be a recognized spatial predicate
-	if (spatial_predicate_map.count(func.function.name) == 0) {
+	if (spatial_predicate_map.count(func.function.GetName()) == 0) {
 		return false;
 	}
 
@@ -117,7 +117,7 @@ static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const uno
 	}
 
 	if (left_side == JoinSide::RIGHT) {
-		if (!HasInversePredicate(func.function.name)) {
+		if (!HasInversePredicate(func.function.GetName())) {
 			return false;
 		}
 		needs_flipping = true;
@@ -190,7 +190,7 @@ static bool TrySwapComparisonJoin(OptimizerExtensionInput &input, unique_ptr<Log
 
 	// If this is ST_DWithin, try to extract the constant distance value
 	const auto &pred_func = spatial_join->spatial_predicate->Cast<BoundFunctionExpression>();
-	if (pred_func.function.name == "ST_DWithin") {
+	if (pred_func.function.GetName() == "ST_DWithin") {
 		// Try to get the constant distance value from the bind data;
 		spatial_join->has_const_distance =
 		    ST_DWithinHelper::TryGetConstDistance(pred_func.bind_info, spatial_join->const_distance);
@@ -296,7 +296,7 @@ static void TrySwapAnyJoin(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
 
 	// If this is ST_DWithin, try to extract the constant distance value
 	const auto &pred_func = spatial_join->spatial_predicate->Cast<BoundFunctionExpression>();
-	if (pred_func.function.name == "ST_DWithin") {
+	if (pred_func.function.GetName() == "ST_DWithin") {
 		// Try to get the constant distance value from the bind data;
 		spatial_join->has_const_distance =
 		    ST_DWithinHelper::TryGetConstDistance(pred_func.bind_info, spatial_join->const_distance);

--- a/src/spatial/operators/spatial_join_optimizer.cpp
+++ b/src/spatial/operators/spatial_join_optimizer.cpp
@@ -71,9 +71,9 @@ static unique_ptr<Expression> GetInversePredicate(ClientContext &context, unique
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, it->second);
 	auto inverse_func =
-	    entry.functions.GetFunctionByArguments(context, {func.children[0]->return_type, func.children[1]->return_type});
+	    entry.functions.GetFunctionByArguments(context, {func.children[0]->GetReturnType(), func.children[1]->GetReturnType()});
 
-	return make_uniq_base<Expression, BoundFunctionExpression>(func.return_type, inverse_func, std::move(func.children),
+	return make_uniq_base<Expression, BoundFunctionExpression>(func.GetReturnType(), inverse_func, std::move(func.children),
 	                                                           nullptr, func.is_operator);
 }
 
@@ -87,7 +87,7 @@ static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const uno
 	}
 
 	// Check if the expression is a spatial predicate
-	if (expr->type != ExpressionType::BOUND_FUNCTION) {
+	if (expr->GetExpressionType() != ExpressionType::BOUND_FUNCTION) {
 		return false;
 	}
 
@@ -99,7 +99,7 @@ static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const uno
 	}
 
 	// The function must return a boolean
-	if (func.return_type != LogicalType::BOOLEAN) {
+	if (func.GetReturnType() != LogicalType::BOOLEAN) {
 		return false;
 	}
 

--- a/src/spatial/operators/spatial_join_physical.cpp
+++ b/src/spatial/operators/spatial_join_physical.cpp
@@ -305,7 +305,7 @@ public:
 		}
 
 		idx_t count = 0;
-		const auto ptr = FlatVector::GetData<data_ptr_t>(state.matches);
+		const auto ptr = FlatVector::GetDataMutable<data_ptr_t>(state.matches);
 		Lookup(state, [&](const data_ptr_t &row) {
 			ptr[count++] = row;
 			return count == STANDARD_VECTOR_SIZE;
@@ -879,7 +879,7 @@ OperatorResultType PhysicalSpatialJoin::ExecuteInternal(ExecutionContext &contex
 	auto &lstate = lstate_p.Cast<SpatialJoinLocalOperatorState>();
 
 	idx_t output_index = 0;
-	idx_t output_count = chunk.GetCapacity();
+	idx_t output_count = STANDARD_VECTOR_SIZE;
 
 	while (true) {
 		switch (lstate.state) {
@@ -1042,7 +1042,7 @@ OperatorResultType PhysicalSpatialJoin::ExecuteInternal(ExecutionContext &contex
 
 			// Also collect the build side row pointers (if we have a match column)
 			if (IsRightOuterJoin(join_type)) {
-				const auto ptrs = FlatVector::GetData<data_ptr_t>(row_pointers);
+				const auto ptrs = FlatVector::GetDataMutable<data_ptr_t>(row_pointers);
 				for (idx_t i = 0; i < scan_count; i++) {
 					lstate.build_side_pointers[output_index + i] = ptrs[i];
 				}
@@ -1257,7 +1257,7 @@ SourceResultType PhysicalSpatialJoin::GetDataInternal(ExecutionContext &context,
 		return SourceResultType::FINISHED;
 	}
 
-	const auto matches = FlatVector::GetData<bool>(lstate.scan_chunk.data.back());
+	const auto matches = FlatVector::GetDataMutable<bool>(lstate.scan_chunk.data.back());
 
 	idx_t result_count = 0;
 	for (idx_t i = 0; i < lstate.scan_chunk.size(); i++) {

--- a/src/spatial/operators/spatial_join_physical.cpp
+++ b/src/spatial/operators/spatial_join_physical.cpp
@@ -444,7 +444,7 @@ PhysicalSpatialJoin::PhysicalSpatialJoin(PhysicalPlan &physical_plan, LogicalOpe
 		conditions_in_layout.emplace(build_side_key->Cast<BoundReferenceExpression>().index, 0); // TODO: i, not 0
 	}
 	// TODO Add rest too
-	build_side_key_types.push_back(build_side_key->return_type);
+	build_side_key_types.push_back(build_side_key->GetReturnType());
 
 	const auto &build_side_input_types = children[1].get().types;
 	auto right_projection_map_copy = FillProjectionMap(children[1].get(), lop.right_projection_map);
@@ -543,7 +543,7 @@ public:
 
 		build_side_payload_chunk.InitializeEmpty(op.build_side_payload_types);
 
-		auto &geom_type = op.build_side_key->return_type;
+		auto &geom_type = op.build_side_key->GetReturnType();
 
 		auto &catalog = Catalog::GetSystemCatalog(context);
 		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_IsEmpty");
@@ -839,8 +839,8 @@ unique_ptr<OperatorState> PhysicalSpatialJoin::GetOperatorState(ExecutionContext
 	// Create a match expression using the condition, that will be used to filter the results
 	lstate->match_expr = condition->Copy();
 	auto &func_expr = lstate->match_expr->Cast<BoundFunctionExpression>();
-	func_expr.children[0] = make_uniq<BoundReferenceExpression>(probe_side_key->return_type, 0);
-	func_expr.children[1] = make_uniq<BoundReferenceExpression>(build_side_key->return_type, 1);
+	func_expr.children[0] = make_uniq<BoundReferenceExpression>(probe_side_key->GetReturnType(), 0);
+	func_expr.children[1] = make_uniq<BoundReferenceExpression>(build_side_key->GetReturnType(), 1);
 
 	lstate->join_match_executor.AddExpression(*lstate->match_expr);
 
@@ -848,15 +848,15 @@ unique_ptr<OperatorState> PhysicalSpatialJoin::GetOperatorState(ExecutionContext
 	lstate->join_probe_executor.AddExpression(*probe_side_key);
 
 	// Make bbox expression for probe side
-	lstate->bound_expr = GetBBOXExpression(context.client, probe_side_key->return_type);
+	lstate->bound_expr = GetBBOXExpression(context.client, probe_side_key->GetReturnType());
 	lstate->bbox_probe_executor.AddExpression(*lstate->bound_expr);
 
 	// The chunks we need for the join
 	lstate->probe_side_row_chunk.Initialize(context.client, probe_side_output_types);
-	lstate->probe_side_key_chunk.Initialize(context.client, {probe_side_key->return_type});
-	lstate->probe_side_box_chunk.Initialize(context.client, {lstate->bound_expr->return_type});
-	lstate->build_side_key_chunk.Initialize(context.client, {build_side_key->return_type});
-	lstate->match_pred_arg_chunk.Initialize(context.client, {probe_side_key->return_type, build_side_key->return_type});
+	lstate->probe_side_key_chunk.Initialize(context.client, {probe_side_key->GetReturnType()});
+	lstate->probe_side_box_chunk.Initialize(context.client, {lstate->bound_expr->GetReturnType()});
+	lstate->build_side_key_chunk.Initialize(context.client, {build_side_key->GetReturnType()});
+	lstate->match_pred_arg_chunk.Initialize(context.client, {probe_side_key->GetReturnType(), build_side_key->GetReturnType()});
 
 	return std::move(lstate);
 }

--- a/src/spatial/operators/spatial_join_physical.cpp
+++ b/src/spatial/operators/spatial_join_physical.cpp
@@ -387,13 +387,13 @@ private:
 static unique_ptr<Expression> GetBBOXExpression(ClientContext &context, const LogicalType &geom_type) {
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_Extent_Approx");
-	auto func = entry.functions.GetFunctionByArguments(context, {geom_type});
+	const auto &func = entry.functions.GetFunctionByArguments(context, {geom_type});
 
 	auto child_expr = make_uniq<BoundReferenceExpression>(geom_type, 0);
 	vector<unique_ptr<Expression>> children;
 	children.push_back(std::move(child_expr));
 
-	auto bbox_expr = make_uniq<BoundFunctionExpression>(GeoTypes::BOX_2DF(), func, std::move(children), nullptr);
+	auto bbox_expr = func.Bind(context, std::move(children));
 
 	return std::move(bbox_expr);
 }
@@ -547,11 +547,11 @@ public:
 
 		auto &catalog = Catalog::GetSystemCatalog(context);
 		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_IsEmpty");
-		auto func = entry.functions.GetFunctionByArguments(context, {geom_type});
+		const auto &func = entry.functions.GetFunctionByArguments(context, {geom_type});
 
-		auto is_empty_expr = make_uniq<BoundFunctionExpression>(LogicalTypeId::BOOLEAN, func,
-		                                                        vector<unique_ptr<Expression>> {}, nullptr);
-		is_empty_expr->children.push_back(make_uniq_base<Expression, BoundReferenceExpression>(geom_type, 0));
+		vector<unique_ptr<Expression>> children;
+		children.push_back(make_uniq_base<Expression, BoundReferenceExpression>(geom_type, 0));
+		auto is_empty_expr = func.Bind(context, std::move(children));
 
 		auto is_not_empty_expr =
 		    make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT, LogicalTypeId::BOOLEAN);

--- a/src/spatial/operators/spatial_join_physical.cpp
+++ b/src/spatial/operators/spatial_join_physical.cpp
@@ -670,8 +670,8 @@ SinkFinalizeType PhysicalSpatialJoin::Finalize(Pipeline &pipeline, Event &event,
 	// We need to keep everything pinned so that we can probe the pointers later
 	TupleDataChunkIterator iterator(*gstate.collection, TupleDataPinProperties::KEEP_EVERYTHING_PINNED, true);
 
-	const auto rows_ptr = iterator.GetRowLocations();
-	Vector row_pointer_vector(LogicalType::POINTER, reinterpret_cast<data_ptr_t>(rows_ptr));
+	auto &row_pointer_vector = iterator.GetChunkState().row_locations;
+	auto rows_ptr = FlatVector::GetData<data_ptr_t>(row_pointer_vector);
 
 	auto &sel = *FlatVector::IncrementalSelectionVector();
 

--- a/src/spatial/operators/spatial_join_physical.cpp
+++ b/src/spatial/operators/spatial_join_physical.cpp
@@ -624,7 +624,7 @@ SinkResultType PhysicalSpatialJoin::Sink(ExecutionContext &context, DataChunk &c
 	}
 
 	if (PropagatesBuildSide(join_type)) {
-		lstate.build_side_row_chunk.data[layout_col_idx++].Reference(Value::BOOLEAN(false));
+		lstate.build_side_row_chunk.data[layout_col_idx++].Reference(Value::BOOLEAN(false), count_t(chunk.size()));
 	}
 
 	// Set the cardinality to match the input

--- a/src/spatial/operators/spatial_join_physical.cpp
+++ b/src/spatial/operators/spatial_join_physical.cpp
@@ -701,6 +701,7 @@ SinkFinalizeType PhysicalSpatialJoin::Finalize(Pipeline &pipeline, Event &event,
 		D_ASSERT(build_side_key_types.size() == 1); // TODO: remove this
 
 		gstate.collection->Gather(row_pointer_vector, sel, row_count, build_side_key_col, geom_vec, sel, nullptr);
+		FlatVector::SetSize(geom_vec, count_t(row_count));
 
 		// This should be flat to begin with, but just to be sure
 		bbox_chunk.Flatten();
@@ -1051,6 +1052,13 @@ OperatorResultType PhysicalSpatialJoin::ExecuteInternal(ExecutionContext &contex
 			output_index += scan_count;
 			lstate.scan.matches_idx += scan_count;
 
+			// Update vector sizes to match the data we have written so far
+			FlatVector::SetSize(lstate.build_side_key_chunk.data[0], count_t(output_index));
+			for (idx_t i = 0; i < build_side_output_columns.size(); i++) {
+				auto &target = chunk.data[probe_side_output_columns.size() + i];
+				FlatVector::SetSize(target, count_t(output_index));
+			}
+
 			if (output_index != output_count) {
 				// We still have space left. Scan more!
 				continue;
@@ -1140,8 +1148,7 @@ OperatorResultType PhysicalSpatialJoin::ExecuteInternal(ExecutionContext &contex
 				// Null the RHS columns
 				for (idx_t i = 0; i < build_side_output_columns.size(); i++) {
 					auto &target = chunk.data[probe_side_output_columns.size() + i];
-					target.SetVectorType(VectorType::CONSTANT_VECTOR);
-					ConstantVector::SetNull(target, true);
+					ConstantVector::SetNull(target, count_t(remaining_count));
 				}
 			}
 
@@ -1267,8 +1274,7 @@ SourceResultType PhysicalSpatialJoin::GetDataInternal(ExecutionContext &context,
 		// Null the LHS columns
 		for (idx_t i = 0; i < lhs_col_count; i++) {
 			auto &target = chunk.data[i];
-			target.SetVectorType(VectorType::CONSTANT_VECTOR);
-			ConstantVector::SetNull(target, true);
+			ConstantVector::SetNull(target, count_t(result_count));
 		}
 
 		// Set the RHS columns

--- a/src/spatial/spatial_types.cpp
+++ b/src/spatial/spatial_types.cpp
@@ -75,7 +75,7 @@ LogicalType GeoTypes::POLYGON_3D() {
 
 LogicalType GeoTypes::CreateEnumType(const string &name, const vector<string> &members) {
 	auto varchar_vector = Vector(LogicalType::VARCHAR, members.size());
-	auto varchar_data = FlatVector::GetData<string_t>(varchar_vector);
+	auto varchar_data = FlatVector::GetDataMutable<string_t>(varchar_vector);
 	for (idx_t i = 0; i < members.size(); i++) {
 		auto str = string_t(members[i]);
 		varchar_data[i] = str.IsInlined() ? str : StringVector::AddString(varchar_vector, str);

--- a/src/spatial/spatial_types.cpp
+++ b/src/spatial/spatial_types.cpp
@@ -128,16 +128,16 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, B
 		}
 	}
 
-	const auto return_has_geom = TypeVisitor::Contains(bound_function.return_type, LogicalTypeId::GEOMETRY);
+	const auto return_has_geom = TypeVisitor::Contains(bound_function.GetReturnType(), LogicalTypeId::GEOMETRY);
 	if (found_crs && return_has_geom) {
 		// If the return type is geometry, we need to set the CRS on it as well
-		bound_function.return_type =
-		    TypeVisitor::VisitReplace(bound_function.return_type, [&](const LogicalType &type) {
+		bound_function.SetReturnType(
+		    TypeVisitor::VisitReplace(bound_function.GetReturnType(), [&](const LogicalType &type) {
 			    if (type.id() == LogicalTypeId::GEOMETRY) {
 				    return LogicalType::GEOMETRY(crs);
 			    }
 			    return type;
-		    });
+		    }));
 	}
 
 	return nullptr;

--- a/src/spatial/spatial_types.cpp
+++ b/src/spatial/spatial_types.cpp
@@ -142,13 +142,19 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, S
 
 	return nullptr;
 }
-unique_ptr<FunctionData> GeoTypes::PropagateCRS(ClientContext &context, ScalarFunction &bound_function,
-                                                vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> GeoTypes::PropagateCRS(BindScalarFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	return PropagateTypesInternal(context, bound_function, arguments);
 }
 
-unique_ptr<FunctionData> GeoTypes::PropagateCRS(ClientContext &context, AggregateFunction &bound_function,
-                                                vector<unique_ptr<Expression>> &arguments) {
+unique_ptr<FunctionData> GeoTypes::PropagateCRS(BindAggregateFunctionInput &input) {
+	auto &context = input.GetClientContext();
+	auto &bound_function = input.GetBoundFunction();
+	auto &arguments = input.GetArguments();
+
 	return PropagateTypesInternal(context, bound_function, arguments);
 }
 

--- a/src/spatial/spatial_types.cpp
+++ b/src/spatial/spatial_types.cpp
@@ -85,7 +85,7 @@ LogicalType GeoTypes::CreateEnumType(const string &name, const vector<string> &m
 	return enum_type;
 }
 
-static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, SimpleFunction &bound_function,
+static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, BoundSimpleFunction &bound_function,
                                                        vector<unique_ptr<Expression>> &arguments) {
 
 	CoordinateReferenceSystem crs;
@@ -115,7 +115,7 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, S
 						    " * Use 'ST_SetCRS' to explicitly override the CRS of a geometry expression, without "
 						    "performing a "
 						    "transformation.\n",
-						    bound_function.name, crs.GetIdentifier(), type_crs.GetIdentifier());
+						    bound_function.GetName(), crs.GetIdentifier(), type_crs.GetIdentifier());
 					}
 				}
 			}

--- a/src/spatial/spatial_types.cpp
+++ b/src/spatial/spatial_types.cpp
@@ -124,7 +124,7 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, S
 
 		if (has_crs) {
 			// Override the type so that we set the CRS
-			bound_function.arguments[arg_idx] = arg->return_type;
+			bound_function.GetArguments()[arg_idx] = arg->return_type;
 		}
 	}
 

--- a/src/spatial/spatial_types.cpp
+++ b/src/spatial/spatial_types.cpp
@@ -96,7 +96,7 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, S
 
 		auto has_crs = false;
 
-		TypeVisitor::Contains(arg->return_type, [&](const LogicalType &type) {
+		TypeVisitor::Contains(arg->GetReturnType(), [&](const LogicalType &type) {
 			if (type.id() == LogicalTypeId::GEOMETRY && GeoType::HasCRS(type)) {
 				has_crs = true;
 				if (!found_crs) {
@@ -106,7 +106,7 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, S
 					auto &type_crs = GeoType::GetCRS(type);
 					if (!crs.Equals(type_crs)) {
 						throw BinderException(
-						    arg->query_location,
+						    arg->GetQueryLocation(),
 						    "Cannot call function '%s' with geometries of different coordinate reference systems "
 						    "(CRS).\n"
 						    "First geometry type is in '%s' which is not compatible with '%s'.\n"
@@ -124,7 +124,7 @@ static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, S
 
 		if (has_crs) {
 			// Override the type so that we set the CRS
-			bound_function.GetArguments()[arg_idx] = arg->return_type;
+			bound_function.GetArguments()[arg_idx] = arg->GetReturnType();
 		}
 	}
 

--- a/src/spatial/spatial_types.cpp
+++ b/src/spatial/spatial_types.cpp
@@ -85,7 +85,7 @@ LogicalType GeoTypes::CreateEnumType(const string &name, const vector<string> &m
 	return enum_type;
 }
 
-static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, BaseScalarFunction &bound_function,
+static unique_ptr<FunctionData> PropagateTypesInternal(ClientContext &context, SimpleFunction &bound_function,
                                                        vector<unique_ptr<Expression>> &arguments) {
 
 	CoordinateReferenceSystem crs;

--- a/src/spatial/spatial_types.hpp
+++ b/src/spatial/spatial_types.hpp
@@ -13,11 +13,11 @@ class ScalarFunction;
 class AggregateFunction;
 class ClientContext;
 class Expression;
+class BindScalarFunctionInput;
+class BindAggregateFunctionInput;
 
-typedef unique_ptr<FunctionData> (*bind_scalar_function_t)(ClientContext &context, ScalarFunction &bound_function,
-                                                           vector<unique_ptr<Expression>> &arguments);
-typedef unique_ptr<FunctionData> (*bind_aggregate_function_t)(ClientContext &context, AggregateFunction &function,
-                                                              vector<unique_ptr<Expression>> &arguments);
+typedef unique_ptr<FunctionData> (*bind_scalar_function_t)(BindScalarFunctionInput &input);
+typedef unique_ptr<FunctionData> (*bind_aggregate_function_t)(BindAggregateFunctionInput &input);
 
 struct GeoTypes {
 	static LogicalType POINT_2D();
@@ -34,25 +34,22 @@ struct GeoTypes {
 
 	static LogicalType CreateEnumType(const string &name, const vector<string> &members);
 
-	static unique_ptr<FunctionData> PropagateCRS(ClientContext &context, ScalarFunction &bound_function,
-	                                             vector<unique_ptr<Expression>> &arguments);
+	static unique_ptr<FunctionData> PropagateCRS(BindScalarFunctionInput &input);
+	static unique_ptr<FunctionData> PropagateCRS(BindAggregateFunctionInput &input);
 
-	static unique_ptr<FunctionData> PropagateCRS(ClientContext &context, AggregateFunction &bound_function,
-	                                             vector<unique_ptr<Expression>> &arguments);
-
-	template <bind_aggregate_function_t BIND>
-	static unique_ptr<FunctionData> PropagateCRS(ClientContext &context, AggregateFunction &bound_function,
-	                                             vector<unique_ptr<Expression>> &arguments) {
-		PropagateCRS(context, bound_function, arguments);
-		return BIND(context, bound_function, arguments);
-	}
 
 	template <bind_scalar_function_t BIND>
-	static unique_ptr<FunctionData> PropagateCRS(ClientContext &context, ScalarFunction &bound_function,
-	                                             vector<unique_ptr<Expression>> &arguments) {
-		PropagateCRS(context, bound_function, arguments);
-		return BIND(context, bound_function, arguments);
+	static unique_ptr<FunctionData> PropagateCRS(BindScalarFunctionInput &input) {
+		PropagateCRS(input);
+		return BIND(input);
 	}
+
+	template <bind_aggregate_function_t BIND>
+	static unique_ptr<FunctionData> PropagateCRS(BindAggregateFunctionInput &input) {
+		PropagateCRS(input);
+		return BIND(input);
+	}
+
 };
 
 } // namespace duckdb

--- a/src/spatial/util/function_builder.hpp
+++ b/src/spatial/util/function_builder.hpp
@@ -74,25 +74,25 @@ inline void ScalarFunctionVariantBuilder::AddParameter(const char *name, const L
 }
 
 inline void ScalarFunctionVariantBuilder::SetReturnType(LogicalType type) {
-	function.return_type = std::move(type);
+	function.SetReturnType(std::move(type));
 }
 
 inline void ScalarFunctionVariantBuilder::SetFunction(scalar_function_t fn) {
-	function.function = fn;
+	function.SetFunctionCallback(fn);
 }
 
 inline void ScalarFunctionVariantBuilder::SetInit(init_local_state_t init) {
-	function.init_local_state = init;
+	function.SetInitStateCallback(init);
 }
 
 inline void ScalarFunctionVariantBuilder::SetBind(bind_scalar_function_t bind) {
-	function.bind = bind;
+	function.SetBindCallback(bind);
 }
 inline void ScalarFunctionVariantBuilder::SetSerialize(function_serialize_t serialize) {
-	function.serialize = serialize;
+	function.SetSerializeCallback(serialize);
 }
 inline void ScalarFunctionVariantBuilder::SetDeserialize(function_deserialize_t deserialize) {
-	function.deserialize = deserialize;
+	function.SetDeserializeCallback(deserialize);
 }
 
 inline void ScalarFunctionVariantBuilder::SetDescription(const string &desc) {
@@ -104,7 +104,7 @@ inline void ScalarFunctionVariantBuilder::SetExample(const string &ex) {
 }
 
 inline void ScalarFunctionVariantBuilder::CanThrowErrors() {
-	function.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	function.SetFallible();
 }
 
 //------------------------------------------------------------------------------
@@ -153,7 +153,7 @@ void ScalarFunctionBuilder::AddVariant(CALLBACK &&callback) {
 	callback(builder);
 
 	// A return type is required
-	if (builder.function.return_type.id() == LogicalTypeId::INVALID) {
+	if (builder.function.GetReturnType().id() == LogicalTypeId::INVALID) {
 		throw InternalException("Return type not set in ScalarFunctionBuilder::AddVariant");
 	}
 
@@ -226,7 +226,7 @@ inline void AggregateFunctionBuilder::SetTag(const string &key, const string &va
 
 inline void AggregateFunctionBuilder::CanThrowErrors() {
 	for (auto &function : set.functions) {
-		function.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+		function.SetFallible();
 	}
 }
 

--- a/src/spatial/util/function_builder.hpp
+++ b/src/spatial/util/function_builder.hpp
@@ -68,7 +68,7 @@ private:
 };
 
 inline void ScalarFunctionVariantBuilder::AddParameter(const char *name, const LogicalType &type) {
-	function.GetArguments().emplace_back(type);
+	function.GetSignature().AddParameter(name, type);
 	description.parameter_names.emplace_back(name);
 	description.parameter_types.emplace_back(type);
 }

--- a/src/spatial/util/function_builder.hpp
+++ b/src/spatial/util/function_builder.hpp
@@ -68,7 +68,7 @@ private:
 };
 
 inline void ScalarFunctionVariantBuilder::AddParameter(const char *name, const LogicalType &type) {
-	function.arguments.emplace_back(type);
+	function.GetArguments().emplace_back(type);
 	description.parameter_names.emplace_back(name);
 	description.parameter_types.emplace_back(type);
 }

--- a/src/spatial/util/managed_collection.hpp
+++ b/src/spatial/util/managed_collection.hpp
@@ -124,7 +124,7 @@ void ManagedCollection<T>::Append(ManagedCollectionAppendState &state, const T *
 		auto to_copy = MinValue<idx_t>(remaining_capacity, remaining_elements);
 
 		// Get the writeable pointer to the block
-		auto ptr = state.handle.Ptr() + state.block->item_count * sizeof(T);
+		auto ptr = state.handle.GetDataMutable() + state.block->item_count * sizeof(T);
 
 		// Store as many elements as we can
 		for (idx_t i = 0; i < to_copy; i++) {

--- a/test/sql/export_import_csv.test
+++ b/test/sql/export_import_csv.test
@@ -25,7 +25,7 @@ INSERT INTO tbl1 VALUES
 
 # Now import and export
 statement ok
-EXPORT DATABASE '__TEST_DIR__/test_export_import_csv';
+EXPORT DATABASE '{TEST_DIR}/test_export_import_csv';
 
 statement ok
 DROP TABLE tbl1;
@@ -39,7 +39,7 @@ does not exist
 # TODO: Somehow this broke in 0.9.2 without us noticing
 
 #statement ok
-#import database '__TEST_DIR__/test_export_import_csv';
+#import database '{TEST_DIR}/test_export_import_csv';
 #
 #query I
 #SELECT ST_AsText(geom) FROM tbl1;

--- a/test/sql/gdal/gdal_axis_order.test
+++ b/test/sql/gdal/gdal_axis_order.test
@@ -8,7 +8,7 @@ INSERT INTO data VALUES (1, ST_MakePoint(100.446569, 0));
 
 # Should error, KML validates coordinate ranges
 statement error
-COPY data TO '__TEST_DIR__/output.kml' WITH (FORMAT GDAL, DRIVER 'KML', SRS 'EPSG:4326');
+COPY data TO '{TEST_DIR}/output.kml' WITH (FORMAT GDAL, DRIVER 'KML', SRS 'EPSG:4326');
 ----
 IO Error: Latitude 100.446569 is invalid. Valid range is [-90,90]. This warning will not be issued any more
 
@@ -18,4 +18,4 @@ SET geometry_always_xy = true;
 
 # Now works
 statement ok
-COPY data TO '__TEST_DIR__/output.kml' WITH (FORMAT GDAL, DRIVER 'KML', SRS 'EPSG:4326');
+COPY data TO '{TEST_DIR}/output.kml' WITH (FORMAT GDAL, DRIVER 'KML', SRS 'EPSG:4326');

--- a/test/sql/gdal/gdal_filter_pushdown.test
+++ b/test/sql/gdal/gdal_filter_pushdown.test
@@ -4,22 +4,22 @@ statement ok
 COPY (
 	SELECT row_number() OVER () as id, point::GEOMETRY
 	FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 100, max_y: 100}::BOX_2D, 10_000, 1337)
-) TO '__TEST_DIR__/pts.fgb' WITH (FORMAT GDAL, DRIVER 'FlatGeoBuf', CRS 'EPSG:4326');
+) TO '{TEST_DIR}/pts.fgb' WITH (FORMAT GDAL, DRIVER 'FlatGeoBuf', CRS 'EPSG:4326');
 
 
 # Test that we can push down the filter to GDAL
 query II
-EXPLAIN SELECT count(*) FROM st_read('__TEST_DIR__/pts.fgb') WHERE geom && ST_MakeEnvelope(45, 45, 65, 65);
+EXPLAIN SELECT count(*) FROM st_read('{TEST_DIR}/pts.fgb') WHERE geom && ST_MakeEnvelope(45, 45, 65, 65);
 ----
 physical_plan	<REGEX>:.*MinX, MinY.*
 
 query II
-EXPLAIN SELECT count(*) FROM st_read('__TEST_DIR__/pts.fgb') WHERE st_intersects_extent(geom, ST_MakeEnvelope(45, 45, 65, 65));
+EXPLAIN SELECT count(*) FROM st_read('{TEST_DIR}/pts.fgb') WHERE st_intersects_extent(geom, ST_MakeEnvelope(45, 45, 65, 65));
 ----
 physical_plan	<REGEX>:.*MinX, MinY.*
 
 # For exact predicates, we push down the bbox, but the exact predicate is still evaluated in DuckDB
 query II
-EXPLAIN SELECT count(*) FROM st_read('__TEST_DIR__/pts.fgb') WHERE st_intersects(geom, ST_MakeEnvelope(45, 45, 65, 65));
+EXPLAIN SELECT count(*) FROM st_read('{TEST_DIR}/pts.fgb') WHERE st_intersects(geom, ST_MakeEnvelope(45, 45, 65, 65));
 ----
 physical_plan	<REGEX>:.*ST_Intersects.*MinX, MinY.*

--- a/test/sql/gdal/gdal_read.test
+++ b/test/sql/gdal/gdal_read.test
@@ -1,26 +1,26 @@
 require spatial
 
 query I
-SELECT COUNT(*) FROM st_read('__WORKING_DIRECTORY__/test/data/amsterdam_roads.fgb') WHERE kind = 'motorway'
+SELECT COUNT(*) FROM st_read('{WORKING_DIRECTORY}/test/data/amsterdam_roads.fgb') WHERE kind = 'motorway'
 ----
 870
 
 statement ok
-CREATE TABLE roads1 AS SELECT * FROM st_read('__WORKING_DIRECTORY__/test/data/amsterdam_roads.fgb') LIMIT 50;
+CREATE TABLE roads1 AS SELECT * FROM st_read('{WORKING_DIRECTORY}/test/data/amsterdam_roads.fgb') LIMIT 50;
 
 # Test Copy
 statement ok
-COPY (SELECT * FROM roads1) TO '__WORKING_DIRECTORY__/test/data/amsterdam_roads_50.geojson'
+COPY (SELECT * FROM roads1) TO '{WORKING_DIRECTORY}/test/data/amsterdam_roads_50.geojson'
 WITH (FORMAT GDAL, DRIVER 'GeoJSON', LAYER_CREATION_OPTIONS 'WRITE_BBOX=YES');
 
 # Test that the copy worked
 query I
-SELECT COUNT(*) FROM st_read('__WORKING_DIRECTORY__/test/data/amsterdam_roads_50.geojson');
+SELECT COUNT(*) FROM st_read('{WORKING_DIRECTORY}/test/data/amsterdam_roads_50.geojson');
 ----
 50
 
 statement ok
-CREATE TABLE roads2 AS SELECT * FROM st_read('__WORKING_DIRECTORY__/test/data/amsterdam_roads_50.geojson');
+CREATE TABLE roads2 AS SELECT * FROM st_read('{WORKING_DIRECTORY}/test/data/amsterdam_roads_50.geojson');
 
 # GDAL I/O should preserve order, so this is safe
 # Compare that the two tables are identical even though they were round-tripped through GDAL

--- a/test/sql/gdal/gdal_shapefile.test
+++ b/test/sql/gdal/gdal_shapefile.test
@@ -2,6 +2,6 @@ require spatial
 
 # This used to fail because our GDAL filesytem wrapper was too aggressive in marking EOF
 query I
-SELECT COUNT(*) FROM st_read('__WORKING_DIRECTORY__/test/data/nyc_export/geo_export_42c9a823-5465-4f85-80b3-b294002094f2.shp');
+SELECT COUNT(*) FROM st_read('{WORKING_DIRECTORY}/test/data/nyc_export/geo_export_42c9a823-5465-4f85-80b3-b294002094f2.shp');
 ----
 5

--- a/test/sql/gdal/gdal_vsi.test
+++ b/test/sql/gdal/gdal_vsi.test
@@ -2,7 +2,7 @@ require spatial
 
 # Test read via VSI
 query I
-SELECT COUNT(*) FROM st_read('/vsigzip/__WORKING_DIRECTORY__/test/data/amsterdam_roads_50.geojson.gz');
+SELECT COUNT(*) FROM st_read('/vsigzip/{WORKING_DIRECTORY}/test/data/amsterdam_roads_50.geojson.gz');
 ----
 50
 
@@ -13,6 +13,6 @@ set enable_external_access = false;
 
 # Test read via VSI
 statement error
-SELECT COUNT(*) FROM st_read('/vsigzip/__WORKING_DIRECTORY__/test/data/amsterdam_roads_50.geojson.gz');
+SELECT COUNT(*) FROM st_read('/vsigzip/{WORKING_DIRECTORY}/test/data/amsterdam_roads_50.geojson.gz');
 ----
 with VSI prefix: External access is disabled

--- a/test/sql/gdal/st_read_gdb.test
+++ b/test/sql/gdal/st_read_gdb.test
@@ -4,19 +4,19 @@
 require spatial
 
 statement error
-COPY (SELECT ST_Point(1,2) as geom, 10 as i) TO '__TEST_DIR__/test.gdb' WITH (FORMAT 'GDAL', DRIVER 'OpenFileGDB');
+COPY (SELECT ST_Point(1,2) as geom, 10 as i) TO '{TEST_DIR}/test.gdb' WITH (FORMAT 'GDAL', DRIVER 'OpenFileGDB');
 ----
 OpenFileGDB requires 'GEOMETRY_TYPE' parameter to be set when writing
 
 statement error
-COPY (SELECT ST_Point(1,2) as geom, 10 as i) TO '__TEST_DIR__/test_fail.gdb' WITH (FORMAT 'GDAL', DRIVER 'OpenFileGDB', GEOMETRY_TYPE 'LINESTRING');
+COPY (SELECT ST_Point(1,2) as geom, 10 as i) TO '{TEST_DIR}/test_fail.gdb' WITH (FORMAT 'GDAL', DRIVER 'OpenFileGDB', GEOMETRY_TYPE 'LINESTRING');
 ----
 Not implemented Error: Can only insert a LineString/MultiLineString/CircularString/CompoundCurve/MultiCurve in a esriGeometryLine layer
 
 statement ok
-COPY (SELECT ST_Point(1,2) as geom, 10 as i) TO '__TEST_DIR__/test.gdb' WITH (FORMAT 'GDAL', DRIVER 'OpenFileGDB', GEOMETRY_TYPE 'POINT');
+COPY (SELECT ST_Point(1,2) as geom, 10 as i) TO '{TEST_DIR}/test.gdb' WITH (FORMAT 'GDAL', DRIVER 'OpenFileGDB', GEOMETRY_TYPE 'POINT');
 
 query II
-FROM st_read('__TEST_DIR__/test.gdb');
+FROM st_read('{TEST_DIR}/test.gdb');
 ----
 10	POINT (1 2)

--- a/test/sql/gdal/st_read_order.test
+++ b/test/sql/gdal/st_read_order.test
@@ -2,26 +2,26 @@ require spatial
 
 # Test that the projection order (i.e. order of columns) dont break anything
 query II
-SELECT kind, geom FROM st_read('__WORKING_DIRECTORY__/test/data/amsterdam_roads.fgb') LIMIT 1;
+SELECT kind, geom FROM st_read('{WORKING_DIRECTORY}/test/data/amsterdam_roads.fgb') LIMIT 1;
 ----
 service	LINESTRING (554203.4169973677 6859025.689313544, 554196.0031192809 6859038.14744868)
 
 query II
-SELECT geom, kind FROM st_read('__WORKING_DIRECTORY__/test/data/amsterdam_roads.fgb') LIMIT 1;
+SELECT geom, kind FROM st_read('{WORKING_DIRECTORY}/test/data/amsterdam_roads.fgb') LIMIT 1;
 ----
 LINESTRING (554203.4169973677 6859025.689313544, 554196.0031192809 6859038.14744868)	service
 
 query I
-SELECT geom FROM st_read('__WORKING_DIRECTORY__/test/data/amsterdam_roads.fgb') LIMIT 1;
+SELECT geom FROM st_read('{WORKING_DIRECTORY}/test/data/amsterdam_roads.fgb') LIMIT 1;
 ----
 LINESTRING (554203.4169973677 6859025.689313544, 554196.0031192809 6859038.14744868)
 
 query I
-SELECT kind FROM st_read('__WORKING_DIRECTORY__/test/data/amsterdam_roads.fgb') LIMIT 1;
+SELECT kind FROM st_read('{WORKING_DIRECTORY}/test/data/amsterdam_roads.fgb') LIMIT 1;
 ----
 service
 
 query III
-SELECT kind, geom, kind FROM st_read('__WORKING_DIRECTORY__/test/data/amsterdam_roads.fgb') LIMIT 1;
+SELECT kind, geom, kind FROM st_read('{WORKING_DIRECTORY}/test/data/amsterdam_roads.fgb') LIMIT 1;
 ----
 service	LINESTRING (554203.4169973677 6859025.689313544, 554196.0031192809 6859038.14744868)	service

--- a/test/sql/gdal/st_read_xlsx.test
+++ b/test/sql/gdal/st_read_xlsx.test
@@ -2,9 +2,9 @@ require spatial
 
 # Test XLSX driver roundtrip
 statement ok
-COPY (SELECT 1337 as i, 'foobar' as f) TO '__TEST_DIR__/test.xlsx' WITH (FORMAT GDAL, DRIVER 'xlsx');
+COPY (SELECT 1337 as i, 'foobar' as f) TO '{TEST_DIR}/test.xlsx' WITH (FORMAT GDAL, DRIVER 'xlsx');
 
 query II
-SELECT i, f FROM st_read('__TEST_DIR__/test.xlsx');
+SELECT i, f FROM st_read('{TEST_DIR}/test.xlsx');
 ----
 1337	foobar

--- a/test/sql/gdal/st_write_basic.test
+++ b/test/sql/gdal/st_write_basic.test
@@ -2,14 +2,14 @@ require spatial
 
 statement ok
 COPY (SELECT ST_GeomFromText('POINT (1 1)'))
-TO '__TEST_DIR__/test_seq.json'
+TO '{TEST_DIR}/test_seq.json'
 WITH (FORMAT GDAL, DRIVER 'GeoJSONSeq');
 
 statement ok
 COPY (SELECT ST_GeomFromText('POINT (1 1)'))
-TO '__TEST_DIR__/test_seq.shp'
+TO '{TEST_DIR}/test_seq.shp'
 WITH (FORMAT GDAL, DRIVER 'ESRI ShapeFile');
 
 # MVT is broken due to threading issues
 #statement ok
-#COPY (SELECT ST_GeomFromText('POINT (1 1)'))  TO '__TEST_DIR__/test_mvt.mvt'  WITH (FORMAT GDAL, DRIVER 'MVT');
+#COPY (SELECT ST_GeomFromText('POINT (1 1)'))  TO '{TEST_DIR}/test_mvt.mvt'  WITH (FORMAT GDAL, DRIVER 'MVT');

--- a/test/sql/gdal/st_write_types.test
+++ b/test/sql/gdal/st_write_types.test
@@ -17,12 +17,12 @@ INSERT INTO st_write_geometry VALUES
 
 # Test Copy
 statement ok
-COPY (SELECT * FROM st_write_geometry) TO '__TEST_DIR__/st_write_geometry.geojson'
+COPY (SELECT * FROM st_write_geometry) TO '{TEST_DIR}/st_write_geometry.geojson'
 WITH (FORMAT GDAL, DRIVER 'GeoJSON', LAYER_CREATION_OPTIONS 'WRITE_BBOX=YES');
 
 # Test reading it back with default options
 query III
-SELECT id, value, geom,  FROM st_read('__TEST_DIR__/st_write_geometry.geojson') ORDER BY id
+SELECT id, value, geom,  FROM st_read('{TEST_DIR}/st_write_geometry.geojson') ORDER BY id
 ----
 1	10.0	POINT (0 0)
 2	20.0	LINESTRING (0 0, 1 1)
@@ -34,7 +34,7 @@ SELECT id, value, geom,  FROM st_read('__TEST_DIR__/st_write_geometry.geojson') 
 
 # Test reading it back as WKB
 query III
-SELECT id, value, ST_GeomFromWKB(wkb_geometry),  FROM st_read('__TEST_DIR__/st_write_geometry.geojson', keep_wkb = true) ORDER BY id
+SELECT id, value, ST_GeomFromWKB(wkb_geometry),  FROM st_read('{TEST_DIR}/st_write_geometry.geojson', keep_wkb = true) ORDER BY id
 ----
 1	10.0	POINT (0 0)
 2	20.0	LINESTRING (0 0, 1 1)

--- a/test/sql/geometry/st_endpoint.test
+++ b/test/sql/geometry/st_endpoint.test
@@ -4,17 +4,17 @@ require spatial
 foreach TYPE GEOMETRY LINESTRING_2D
 
 query I
-SELECT st_astext(st_endpoint(ST_GeomFromText('LINESTRING(0 0, 1 1, 2 2, 3 3)')::${TYPE}));
+SELECT st_astext(st_endpoint(ST_GeomFromText('LINESTRING(0 0, 1 1, 2 2, 3 3)')::{TYPE}));
 ----
 POINT (3 3)
 
 query I
-SELECT st_astext(st_endpoint(ST_GeomFromText('LINESTRING(4 4, 1 1)')::${TYPE}));
+SELECT st_astext(st_endpoint(ST_GeomFromText('LINESTRING(4 4, 1 1)')::{TYPE}));
 ----
 POINT (1 1)
 
 query I
-SELECT st_astext(st_endpoint(ST_GeomFromText('LINESTRING EMPTY')::${TYPE}));
+SELECT st_astext(st_endpoint(ST_GeomFromText('LINESTRING EMPTY')::{TYPE}));
 ----
 NULL
 

--- a/test/sql/geometry/st_exteriorring.test
+++ b/test/sql/geometry/st_exteriorring.test
@@ -3,25 +3,25 @@ require spatial
 foreach TYPE GEOMETRY POLYGON_2D
 
 query I
-SELECT st_exteriorring(st_geomfromtext('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')::${TYPE});
+SELECT st_exteriorring(st_geomfromtext('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')::{TYPE});
 ----
 LINESTRING (0 0, 1 0, 1 1, 0 1, 0 0)
 
 query I
-SELECT st_exteriorring(st_geomfromtext('POLYGON EMPTY')::${TYPE});
+SELECT st_exteriorring(st_geomfromtext('POLYGON EMPTY')::{TYPE});
 ----
 LINESTRING EMPTY
 
 query I
-SELECT st_exteriorring(st_geomfromtext('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0), (0.25 0.25, 0.75 0.25, 0.75 0.75, 0.25 0.75, 0.25 0.25))')::${TYPE});
+SELECT st_exteriorring(st_geomfromtext('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0), (0.25 0.25, 0.75 0.25, 0.75 0.75, 0.25 0.75, 0.25 0.25))')::{TYPE});
 ----
 LINESTRING (0 0, 1 0, 1 1, 0 1, 0 0)
 
 query I
 SELECT st_exteriorring(geom) FROM (VALUES
-    (st_geomfromtext('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')::${TYPE}),
-    (st_geomfromtext('POLYGON EMPTY')::${TYPE}),
-    (st_geomfromtext('POLYGON((0 0, 2 0, 1 1, 0 2, 0 0), (0.25 0.25, 0.75 0.25, 0.75 0.75, 0.25 0.75, 0.25 0.25))')::${TYPE})
+    (st_geomfromtext('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')::{TYPE}),
+    (st_geomfromtext('POLYGON EMPTY')::{TYPE}),
+    (st_geomfromtext('POLYGON((0 0, 2 0, 1 1, 0 2, 0 0), (0.25 0.25, 0.75 0.25, 0.75 0.75, 0.25 0.75, 0.25 0.25))')::{TYPE})
  ) AS t(geom);
 ----
 LINESTRING (0 0, 1 0, 1 1, 0 1, 0 0)

--- a/test/sql/geometry/st_has.test
+++ b/test/sql/geometry/st_has.test
@@ -8,74 +8,74 @@ foreach FUNCTION ST_GeomFromText() ST_GeomFromText().ST_AsWKB()::WKB_BLOB
 
 # HasZ for a 2D geometry
 query I
-SELECT ST_HasZ(('POINT(1 1)').${FUNCTION});
+SELECT ST_HasZ(('POINT(1 1)').{FUNCTION});
 ----
 false
 
 # HasZ for a 3DZ geometry
 query I
-SELECT ST_HasZ(('POINT Z(1 1 1)').${FUNCTION});
+SELECT ST_HasZ(('POINT Z(1 1 1)').{FUNCTION});
 ----
 true
 
 # HasZ for a 3DM geometry
 query I
-SELECT ST_HasZ(('POINT M(1 1 1)').${FUNCTION});
+SELECT ST_HasZ(('POINT M(1 1 1)').{FUNCTION});
 ----
 false
 
 # HasZ for a 4D geometry
 query I
-SELECT ST_HasZ(('POINT ZM(1 1 1 1)').${FUNCTION});
+SELECT ST_HasZ(('POINT ZM(1 1 1 1)').{FUNCTION});
 ----
 true
 
 # HasM for a 2D geometry
 query I
-SELECT ST_HasM(('POINT(1 1)').${FUNCTION});
+SELECT ST_HasM(('POINT(1 1)').{FUNCTION});
 ----
 false
 
 # HasM for a 3DZ geometry
 query I
-SELECT ST_HasM(('POINT Z(1 1 1)').${FUNCTION});
+SELECT ST_HasM(('POINT Z(1 1 1)').{FUNCTION});
 ----
 false
 
 # HasM for a 3DM geometry
 query I
-SELECT ST_HasM(('POINT M(1 1 1)').${FUNCTION});
+SELECT ST_HasM(('POINT M(1 1 1)').{FUNCTION});
 ----
 true
 
 # HasM for a 4D geometry
 query I
-SELECT ST_HasM(('POINT ZM(1 1 1 1)').${FUNCTION});
+SELECT ST_HasM(('POINT ZM(1 1 1 1)').{FUNCTION});
 ----
 true
 
 # ZMFlag for a 2D geometry
 query I
-SELECT ST_ZMFlag(('POINT(1 1)').${FUNCTION});
+SELECT ST_ZMFlag(('POINT(1 1)').{FUNCTION});
 ----
 0
 
 
 # ZMFlag for a 3DZ geometry
 query I
-SELECT ST_ZMFlag(('POINT Z(1 1 1)').${FUNCTION});
+SELECT ST_ZMFlag(('POINT Z(1 1 1)').{FUNCTION});
 ----
 2
 
 # ZMFlag for a 3DM geometry
 query I
-SELECT ST_ZMFlag(('POINT M(1 1 1)').${FUNCTION});
+SELECT ST_ZMFlag(('POINT M(1 1 1)').{FUNCTION});
 ----
 1
 
 # ZMFlag for a 4D geometry
 query I
-SELECT ST_ZMFlag(('POINT ZM(1 1 1 1)').${FUNCTION});
+SELECT ST_ZMFlag(('POINT ZM(1 1 1 1)').{FUNCTION});
 ----
 3
 

--- a/test/sql/geometry/st_interiorringn.test
+++ b/test/sql/geometry/st_interiorringn.test
@@ -6,7 +6,7 @@ query I
 select st_interiorringn(
     st_geomfromtext('POLYGON((0 0,10 0,10 10,0 10,0 0),
                              (2 2,4 2,4 4,2 4,2 2),
-                             (6 6,8 6,8 8,6 8,6 6))')::${TYPE},
+                             (6 6,8 6,8 8,6 8,6 6))')::{TYPE},
     2
 );
 ----
@@ -16,7 +16,7 @@ query I
 select st_interiorringn(
     st_geomfromtext('POLYGON((0 0,10 0,10 10,0 10,0 0),
                              (2 2,4 2,4 4,2 4,2 2),
-                             (6 6,8 6,8 8,6 8,6 6))')::${TYPE},
+                             (6 6,8 6,8 8,6 8,6 6))')::{TYPE},
     3
 );
 ----
@@ -24,7 +24,7 @@ NULL
 
 query I
 select st_interiorringn(
-    st_geomfromtext('POLYGON EMPTY')::${TYPE},
+    st_geomfromtext('POLYGON EMPTY')::{TYPE},
     3
 );
 ----
@@ -32,7 +32,7 @@ NULL
 
 query I
 select st_interiorringn(
-    st_geomfromtext('POLYGON EMPTY')::${TYPE},
+    st_geomfromtext('POLYGON EMPTY')::{TYPE},
     0
 );
 ----

--- a/test/sql/geometry/st_ninteriorrings.test
+++ b/test/sql/geometry/st_ninteriorrings.test
@@ -3,17 +3,17 @@ require spatial
 foreach TYPE GEOMETRY POLYGON_2D
 
 query I
-SELECT st_ninteriorrings(ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')::${TYPE});
+SELECT st_ninteriorrings(ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')::{TYPE});
 ----
 0
 
 query I
-SELECT st_ninteriorrings(ST_GeomFromText('POLYGON EMPTY')::${TYPE});
+SELECT st_ninteriorrings(ST_GeomFromText('POLYGON EMPTY')::{TYPE});
 ----
 0
 
 query I
-SELECT st_ninteriorrings(ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0), (0.25 0.25, 0.25 0.75, 0.75 0.75, 0.75 0.25, 0.25 0.25))')::${TYPE});
+SELECT st_ninteriorrings(ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0), (0.25 0.25, 0.25 0.75, 0.75 0.75, 0.75 0.25, 0.25 0.25))')::{TYPE});
 ----
 1
 

--- a/test/sql/geometry/st_pointn.test
+++ b/test/sql/geometry/st_pointn.test
@@ -4,7 +4,7 @@ require spatial
 foreach TYPE GEOMETRY LINESTRING_2D
 
 query I
-SELECT st_pointn(ST_GeomFromText('LINESTRING(0 0, 1 1, 2 2, 3 3)')::${TYPE}, 2);
+SELECT st_pointn(ST_GeomFromText('LINESTRING(0 0, 1 1, 2 2, 3 3)')::{TYPE}, 2);
 ----
 POINT (1 1)
 

--- a/test/sql/geometry/st_removerepeatedlines.test
+++ b/test/sql/geometry/st_removerepeatedlines.test
@@ -11,52 +11,52 @@ LINESTRING (1 1, 1 1)
 
 # Remove points in the middle
 query I
-SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (1 1, 2 2, 2 2, 3 3)')::${kind}));
+SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (1 1, 2 2, 2 2, 3 3)')::{kind}));
 ----
 LINESTRING (1 1, 2 2, 3 3)
 
 query I
-SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (1 1, 2 2, 2 2, 2 2, 4 4, 4 4, 3 3)')::${kind}));
+SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (1 1, 2 2, 2 2, 2 2, 4 4, 4 4, 3 3)')::{kind}));
 ----
 LINESTRING (1 1, 2 2, 4 4, 3 3)
 
 # Remove points in the front
 query I
-SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (1 1, 1 1, 2 2, 3 3)')::${kind}));
+SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (1 1, 1 1, 2 2, 3 3)')::{kind}));
 ----
 LINESTRING (1 1, 2 2, 3 3)
 
 # Remove points from the back
 query I
-SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (1 1, 2 2, 3 3, 3 3)')::${kind}));
+SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (1 1, 2 2, 3 3, 3 3)')::{kind}));
 ----
 LINESTRING (1 1, 2 2, 3 3)
 
 
 # With tolerance
 query I
-SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (2 2, 1 1, 5 5, 1 1, 0 0, 0 0)')::${kind}, 2))
+SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (2 2, 1 1, 5 5, 1 1, 0 0, 0 0)')::{kind}, 2))
 ----
 LINESTRING (2 2, 5 5, 0 0)
 
 query I
-SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (0 0, 0 0, 1 1, 5 5, 1 1, 2 2)')::${kind}, 2))
+SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (0 0, 0 0, 1 1, 5 5, 1 1, 2 2)')::{kind}, 2))
 ----
 LINESTRING (0 0, 5 5, 2 2)
 
 query I
-SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (0 0, 0.5 0, 1 0)')::${kind}, 0.75));
+SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (0 0, 0.5 0, 1 0)')::{kind}, 0.75));
 ----
 LINESTRING (0 0, 1 0)
 
 # Ensure we the start and end are unchanged
 query I
-SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (0 0, 1 1, 2 2, 3 3)')::${kind}, 100));
+SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (0 0, 1 1, 2 2, 3 3)')::{kind}, 100));
 ----
 LINESTRING (0 0, 3 3)
 
 query I
-SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (1 1, 1 1, 1 1, 1 1)')::${kind}, 2));
+SELECT ST_AsText(ST_RemoveRepeatedPoints(ST_GeomFromText('LINESTRING (1 1, 1 1, 1 1, 1 1)')::{kind}, 2));
 ----
 LINESTRING (1 1, 1 1)
 

--- a/test/sql/geometry/st_startpoint.test
+++ b/test/sql/geometry/st_startpoint.test
@@ -4,17 +4,17 @@ require spatial
 foreach TYPE GEOMETRY LINESTRING_2D
 
 query I
-SELECT st_astext(st_startpoint(ST_GeomFromText('LINESTRING(0 0, 1 1, 2 2, 3 3)')::${TYPE}));
+SELECT st_astext(st_startpoint(ST_GeomFromText('LINESTRING(0 0, 1 1, 2 2, 3 3)')::{TYPE}));
 ----
 POINT (0 0)
 
 query I
-SELECT st_astext(st_startpoint(ST_GeomFromText('LINESTRING(4 4, 1 1)')::${TYPE}));
+SELECT st_astext(st_startpoint(ST_GeomFromText('LINESTRING(4 4, 1 1)')::{TYPE}));
 ----
 POINT (4 4)
 
 query I
-SELECT st_astext(st_startpoint(ST_GeomFromText('LINESTRING EMPTY')::${TYPE}));
+SELECT st_astext(st_startpoint(ST_GeomFromText('LINESTRING EMPTY')::{TYPE}));
 ----
 NULL
 

--- a/test/sql/index/rtree_basic.test
+++ b/test/sql/index/rtree_basic.test
@@ -1,9 +1,6 @@
 require spatial
 
 statement ok
-PRAGMA enable_verification;
-
-statement ok
 CREATE TABLE t1 (geom GEOMETRY);
 
 statement ok

--- a/test/sql/index/rtree_basic_data.test_slow
+++ b/test/sql/index/rtree_basic_data.test_slow
@@ -4,7 +4,7 @@ require spatial
 
 statement ok
 CREATE TABLE t1 as SELECT st_point(pickup_longitude, pickup_latitude) as geom, trip_distance, fare_amount
-FROM read_parquet('__WORKING_DIRECTORY__/test/data/nyc_taxi/yellow_tripdata_2010-01-limit1mil.parquet');
+FROM read_parquet('{WORKING_DIRECTORY}/test/data/nyc_taxi/yellow_tripdata_2010-01-limit1mil.parquet');
 
 query I
 SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(-74.004936,40.725275,-73.982620,40.745046));

--- a/test/sql/index/rtree_basic_points.test
+++ b/test/sql/index/rtree_basic_points.test
@@ -1,9 +1,6 @@
 require spatial
 
 statement ok
-PRAGMA enable_verification;
-
-statement ok
 CREATE TABLE t1 AS SELECT point::GEOMETRY as geom
 FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 1000, max_y: 1000}::BOX_2D, 100_00, 1337);
 

--- a/test/sql/index/rtree_block_reclaim.test_slow
+++ b/test/sql/index/rtree_block_reclaim.test_slow
@@ -3,9 +3,6 @@ require spatial
 load {TEST_DIR}/rtree_reclaim_space.db
 
 statement ok
-PRAGMA enable_verification;
-
-statement ok
 CREATE TABLE tbl AS SELECT row_number() over () as i, geom::GEOMETRY as geom FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 10000, max_y: 10000}::BOX_2D, 100_000, 1337) as pts(geom);
 
 statement ok

--- a/test/sql/index/rtree_block_reclaim.test_slow
+++ b/test/sql/index/rtree_block_reclaim.test_slow
@@ -1,6 +1,6 @@
 require spatial
 
-load __TEST_DIR__/rtree_reclaim_space.db
+load {TEST_DIR}/rtree_reclaim_space.db
 
 statement ok
 PRAGMA enable_verification;

--- a/test/sql/index/rtree_empty.test
+++ b/test/sql/index/rtree_empty.test
@@ -1,9 +1,6 @@
 require spatial
 
 statement ok
-PRAGMA enable_verification;
-
-statement ok
 CREATE TABLE t1(i INT, g GEOMETRY);
 
 statement ok

--- a/test/sql/index/rtree_filter_pullup.test
+++ b/test/sql/index/rtree_filter_pullup.test
@@ -3,7 +3,7 @@ require spatial
 require parquet
 
 query I rowsort
-SELECT id FROM '__WORKING_DIRECTORY__/test/data/segments.parquet'
+SELECT id FROM '{WORKING_DIRECTORY}/test/data/segments.parquet'
 WHERE subtype='road' AND ST_Intersects(geometry, ST_Buffer(ST_GeomFromText('POINT (-8476562 4795814)'), 100));
 ----
 0862aac667ffffff043df7e4c6756d14
@@ -12,7 +12,7 @@ WHERE subtype='road' AND ST_Intersects(geometry, ST_Buffer(ST_GeomFromText('POIN
 
 
 query III rowsort
-SELECT id, subtype, class FROM '__WORKING_DIRECTORY__/test/data/segments.parquet'
+SELECT id, subtype, class FROM '{WORKING_DIRECTORY}/test/data/segments.parquet'
 WHERE subtype='road' AND class='residential' AND ST_Intersects(geometry, ST_Buffer(ST_GeomFromText('POINT (-8476562 4795814)'), 100));
 ----
 0862aac667ffffff047de7f2111f86ad	road	residential

--- a/test/sql/index/rtree_multi.test
+++ b/test/sql/index/rtree_multi.test
@@ -4,9 +4,6 @@
 require spatial
 
 statement ok
-PRAGMA enable_verification;
-
-statement ok
 CREATE TABLE t1 (id INT, g1 GEOMETRY, g2 GEOMETRY);
 
 statement ok

--- a/test/sql/index/rtree_persistence.test_slow
+++ b/test/sql/index/rtree_persistence.test_slow
@@ -1,7 +1,7 @@
 require spatial
 
 # Create a persistent database
-load __TEST_DIR__/rtree_persistence_test.db
+load {TEST_DIR}/rtree_persistence_test.db
 
 statement ok
 CREATE TABLE t1 AS SELECT point::GEOMETRY as geom

--- a/test/sql/index/rtree_persistence_load.test
+++ b/test/sql/index/rtree_persistence_load.test
@@ -1,7 +1,7 @@
 require spatial
 
 # Create a persistent database
-load __TEST_DIR__/rtree_persistence_test.db
+load {TEST_DIR}/rtree_persistence_test.db
 
 statement ok
 CREATE TABLE t1 AS SELECT point::GEOMETRY as geom

--- a/test/sql/index/rtree_persistence_wal.test
+++ b/test/sql/index/rtree_persistence_wal.test
@@ -1,7 +1,7 @@
 require spatial
 
 # Create a persistent database
-load __TEST_DIR__/rtree_persistence_wal_test.db
+load {TEST_DIR}/rtree_persistence_wal_test.db
 
 statement ok
 PRAGMA disable_checkpoint_on_shutdown;

--- a/test/sql/index/rtree_projection.test
+++ b/test/sql/index/rtree_projection.test
@@ -1,9 +1,6 @@
 require spatial
 
 statement ok
-PRAGMA enable_verification;
-
-statement ok
 CREATE TABLE t1 (id int, geom GEOMETRY);
 
 statement ok

--- a/test/sql/index/rtree_pushdown.test
+++ b/test/sql/index/rtree_pushdown.test
@@ -1,9 +1,6 @@
 require spatial
 
 statement ok
-PRAGMA enable_verification;
-
-statement ok
 CREATE TABLE t1 (geom GEOMETRY, id INT);
 
 statement ok

--- a/test/sql/index/rtree_single.test
+++ b/test/sql/index/rtree_single.test
@@ -1,9 +1,6 @@
 require spatial
 
 statement ok
-PRAGMA enable_verification;
-
-statement ok
 CREATE TABLE t1(i INT, g GEOMETRY);
 
 statement ok

--- a/test/sql/index/rtree_transaction.test
+++ b/test/sql/index/rtree_transaction.test
@@ -1,9 +1,6 @@
 require spatial
 
 statement ok
-PRAGMA enable_verification;
-
-statement ok
 BEGIN TRANSACTION;
 
 statement ok

--- a/test/sql/join/spatial_join_empty.test
+++ b/test/sql/join/spatial_join_empty.test
@@ -1,8 +1,5 @@
 require spatial
 
-statement ok
-PRAGMA enable_verification
-
 # Create a bunch of points on a grid
 # between 0 and 500 in both x and y directions
 statement ok

--- a/test/sql/join/spatial_join_empty_build.test
+++ b/test/sql/join/spatial_join_empty_build.test
@@ -1,9 +1,6 @@
 require spatial
 
 statement ok
-PRAGMA enable_verification
-
-statement ok
 CREATE TABLE lhs AS
 SELECT
     ST_Point(x, y) as geom,

--- a/test/sql/join/spatial_join_extra_pred.test
+++ b/test/sql/join/spatial_join_extra_pred.test
@@ -1,9 +1,6 @@
 require spatial
 
 statement ok
-PRAGMA enable_verification
-
-statement ok
 CREATE TABLE t1 AS
 SELECT
     ST_Buffer(ST_Point(x, y), 5) as geom,

--- a/test/sql/join/spatial_join_predicates.test
+++ b/test/sql/join/spatial_join_predicates.test
@@ -1,8 +1,5 @@
 require spatial
 
-statement ok
-PRAGMA enable_verification
-
 # Set up test tables
 statement ok
 CREATE TABLE lhs AS

--- a/test/sql/join/spatial_join_test_2.test_slow
+++ b/test/sql/join/spatial_join_test_2.test_slow
@@ -24,7 +24,7 @@ INSERT INTO t2 SELECT
 					st_point(x + 70, y),
 					list_transform(
 						list_sort([{u: random() * 2 * 3.14, w: (random() * 2 - 1) * 15} for _ in range(1,16)]),
-						v -> st_point(x + cos(v.u) * 70 + cos(v.u) * v.w, y + sin(v.u) * 70 + sin(v.u) * v.w))
+						lambda v: st_point(x + cos(v.u) * 70 + cos(v.u) * v.w, y + sin(v.u) * 70 + sin(v.u) * v.w))
 				),
 				st_point(x + 70, y)
 			)

--- a/test/sql/join/spatial_join_test_3.test_slow
+++ b/test/sql/join/spatial_join_test_3.test_slow
@@ -1,9 +1,6 @@
 require spatial
 
 statement ok
-PRAGMA enable_verification
-
-statement ok
 SELECT setseed(0.5);
 
 statement ok

--- a/test/sql/join/spatial_join_test_3.test_slow
+++ b/test/sql/join/spatial_join_test_3.test_slow
@@ -19,7 +19,7 @@ INSERT INTO t1 SELECT
 					st_point(x + 70, y),
 					list_transform(
 						list_sort([{u: random() * 2 * 3.14, w: (random() * 2 - 1) * 15} for _ in range(1,16)]),
-						v -> st_point(x + cos(v.u) * 70 + cos(v.u) * v.w, y + sin(v.u) * 70 + sin(v.u) * v.w))
+						lambda v: st_point(x + cos(v.u) * 70 + cos(v.u) * v.w, y + sin(v.u) * 70 + sin(v.u) * v.w))
 				),
 				st_point(x + 70, y)
 			)

--- a/test/sql/mvt/st_asmvt.test
+++ b/test/sql/mvt/st_asmvt.test
@@ -17,10 +17,10 @@ COPY (
 		FROM range(0, 100) as r(x),
 			 range(0, 100) as rr(y)
 	)
-) TO '__TEST_DIR__/test_default_args.mvt' (FORMAT BLOB);
+) TO '{TEST_DIR}/test_default_args.mvt' (FORMAT BLOB);
 
 query IIII
-select unnest(layers, recursive := true) from st_read_meta('__TEST_DIR__/test_default_args.mvt');
+select unnest(layers, recursive := true) from st_read_meta('{TEST_DIR}/test_default_args.mvt');
 ----
 my_layer	10000	[{'name': geom, 'type': Point, 'nullable': true, 'crs': NULL}]	[{'name': mvt_id, 'type': Integer64, 'subtype': None, 'nullable': true, 'unique': false, 'width': 0, 'precision': 0}]
 
@@ -41,16 +41,16 @@ COPY (
 		FROM range(0, 100) as r(x),
 			 range(0, 100) as rr(y)
 	)
-) TO '__TEST_DIR__/test.mvt' (FORMAT BLOB);
+) TO '{TEST_DIR}/test.mvt' (FORMAT BLOB);
 
 query IIII
-select unnest(layers, recursive := true) from st_read_meta('__TEST_DIR__/test.mvt');
+select unnest(layers, recursive := true) from st_read_meta('{TEST_DIR}/test.mvt');
 ----
 my_layer	10000	[{'name': geom, 'type': Point, 'nullable': true, 'crs': NULL}]	[{'name': mvt_id, 'type': Integer64, 'subtype': None, 'nullable': true, 'unique': false, 'width': 0, 'precision': 0}]
 
 
 query I
-select mvt_id from st_read('__TEST_DIR__/test.mvt') limit 3;
+select mvt_id from st_read('{TEST_DIR}/test.mvt') limit 3;
 ----
 1
 2
@@ -81,15 +81,15 @@ COPY (
 		FROM range(0, 100) as r(x),
 			 range(0, 100) as rr(y)
 	)
-) TO '__TEST_DIR__/test2.mvt' (FORMAT BLOB);
+) TO '{TEST_DIR}/test2.mvt' (FORMAT BLOB);
 
 query IIII
-select unnest(layers, recursive := true) from st_read_meta('__TEST_DIR__/test2.mvt');
+select unnest(layers, recursive := true) from st_read_meta('{TEST_DIR}/test2.mvt');
 ----
 my_layer	10000	[{'name': geom, 'type': Polygon, 'nullable': true, 'crs': NULL}]	[{'name': mvt_id, 'type': Integer64, 'subtype': None, 'nullable': true, 'unique': false, 'width': 0, 'precision': 0}, {'name': int_field, 'type': Integer, 'subtype': None, 'nullable': true, 'unique': false, 'width': 0, 'precision': 0}, {'name': bigint_field, 'type': Integer, 'subtype': None, 'nullable': true, 'unique': false, 'width': 0, 'precision': 0}, {'name': float_field, 'type': Real, 'subtype': Float32, 'nullable': true, 'unique': false, 'width': 0, 'precision': 0}, {'name': double_field, 'type': Real, 'subtype': None, 'nullable': true, 'unique': false, 'width': 0, 'precision': 0}, {'name': string_field, 'type': String, 'subtype': None, 'nullable': true, 'unique': false, 'width': 0, 'precision': 0}]
 
 query IIIIII
-select mvt_id, int_field, bigint_field, float_field, double_field, string_field from st_read('__TEST_DIR__/test2.mvt') LIMIT 3;
+select mvt_id, int_field, bigint_field, float_field, double_field, string_field from st_read('{TEST_DIR}/test2.mvt') LIMIT 3;
 ----
 NULL	1	1	1.0	1.0	1
 NULL	2	2	2.0	2.0	2
@@ -113,7 +113,7 @@ COPY (
 		FROM range(0, 100) as r(x),
 			 range(0, 100) as rr(y)
 	)
-) TO '__TEST_DIR__/test3.mvt' (FORMAT BLOB);
+) TO '{TEST_DIR}/test3.mvt' (FORMAT BLOB);
 ----
 Invalid Input Error: ST_AsMVT: property column "other_field" has unsupported type "GEOMETRY"
 Only the following property types are supported: VARCHAR, FLOAT, DOUBLE, INTEGER, BIGINT, BOOLEAN

--- a/test/sql/mvt/st_asmvt_linestring.test
+++ b/test/sql/mvt/st_asmvt_linestring.test
@@ -14,10 +14,10 @@ COPY (
 		SELECT
 			st_geomfromtext('LINESTRING(0 0, 100 100, 200 0)') as geom
 	)
-) TO '__TEST_DIR__/test_linestring.mvt' (FORMAT BLOB);
+) TO '{TEST_DIR}/test_linestring.mvt' (FORMAT BLOB);
 
 query I
-select count(*) from st_read('__TEST_DIR__/test_linestring.mvt');
+select count(*) from st_read('{TEST_DIR}/test_linestring.mvt');
 ----
 1
 
@@ -32,10 +32,10 @@ COPY (
 		SELECT
 			st_geomfromtext('MULTILINESTRING((0 0, 100 100, 200 0), (300 0, 400 100, 500 0))') as geom
 	)
-) TO '__TEST_DIR__/test_multilinestring.mvt' (FORMAT BLOB);
+) TO '{TEST_DIR}/test_multilinestring.mvt' (FORMAT BLOB);
 
 query I
-select count(*) from st_read('__TEST_DIR__/test_multilinestring.mvt');
+select count(*) from st_read('{TEST_DIR}/test_multilinestring.mvt');
 ----
 1
 
@@ -56,10 +56,10 @@ COPY (
 		SELECT
 			st_geomfromtext('LINESTRING(100 100, 500 500, 900 100)') as geom
 	)
-) TO '__TEST_DIR__/test_clipped_linestring.mvt' (FORMAT BLOB);
+) TO '{TEST_DIR}/test_clipped_linestring.mvt' (FORMAT BLOB);
 
 query I
-select count(*) from st_read('__TEST_DIR__/test_clipped_linestring.mvt');
+select count(*) from st_read('{TEST_DIR}/test_clipped_linestring.mvt');
 ----
 1
 
@@ -80,10 +80,10 @@ COPY (
 		SELECT
 			st_geomfromtext('LINESTRING(-500 500, 500 500, 1500 500)') as geom
 	)
-) TO '__TEST_DIR__/test_crossing_linestring.mvt' (FORMAT BLOB);
+) TO '{TEST_DIR}/test_crossing_linestring.mvt' (FORMAT BLOB);
 
 query I
-select count(*) from st_read('__TEST_DIR__/test_crossing_linestring.mvt');
+select count(*) from st_read('{TEST_DIR}/test_crossing_linestring.mvt');
 ----
 1
 
@@ -104,10 +104,10 @@ COPY (
 		FROM range(0, 10) as r(x),
 			 range(0, 10) as rr(y)
 	)
-) TO '__TEST_DIR__/test_various_linestrings.mvt' (FORMAT BLOB);
+) TO '{TEST_DIR}/test_various_linestrings.mvt' (FORMAT BLOB);
 
 query I
-select count(*) from st_read('__TEST_DIR__/test_various_linestrings.mvt');
+select count(*) from st_read('{TEST_DIR}/test_various_linestrings.mvt');
 ----
 100
 
@@ -129,10 +129,10 @@ COPY (
 		SELECT
 			st_geomfromtext('LINESTRING(-10000000 5000000, 0 0, 10000000 -5000000)') as geom
 	)
-) TO '__TEST_DIR__/test_global_linestring.mvt' (FORMAT BLOB);
+) TO '{TEST_DIR}/test_global_linestring.mvt' (FORMAT BLOB);
 
 query I
-select count(*) from st_read('__TEST_DIR__/test_global_linestring.mvt');
+select count(*) from st_read('{TEST_DIR}/test_global_linestring.mvt');
 ----
 1
 
@@ -148,10 +148,10 @@ COPY (
 			(st_geomfromtext('MULTILINESTRING((100 100, 500 500), (600 600, 900 900))'), 'road1'),
 			(st_geomfromtext('LINESTRING(200 200, 800 800)'), 'road2')
 	) t(geom, name)
-) TO '__TEST_DIR__/test_roads.mvt' (FORMAT BLOB);
+) TO '{TEST_DIR}/test_roads.mvt' (FORMAT BLOB);
 
 query II
-select count(*), count(name) from st_read('__TEST_DIR__/test_roads.mvt');
+select count(*), count(name) from st_read('{TEST_DIR}/test_roads.mvt');
 ----
 2	2
 

--- a/test/sql/mvt/st_tileenvelope.test
+++ b/test/sql/mvt/st_tileenvelope.test
@@ -5,9 +5,6 @@
 
 require spatial
 
-statement ok
-PRAGMA enable_verification
-
 query I
 SELECT ST_NumPoints( ST_ExteriorRing( ST_TileEnvelope(2, 3, 1) ) );
 ----

--- a/test/sql/shapefile/test_shapefile_read.test
+++ b/test/sql/shapefile/test_shapefile_read.test
@@ -4,13 +4,13 @@ require spatial
 
 statement ok
 COPY (
-    SELECT * FROM st_read('__WORKING_DIRECTORY__/test/data/world-administrative-boundaries.geojson')
-) TO '__TEST_DIR__/world_admin.shp' (FORMAT 'GDAL', DRIVER 'ESRI Shapefile');
+    SELECT * FROM st_read('{WORKING_DIRECTORY}/test/data/world-administrative-boundaries.geojson')
+) TO '{TEST_DIR}/world_admin.shp' (FORMAT 'GDAL', DRIVER 'ESRI Shapefile');
 
 query III rowsort expected_result
-SELECT name, st_area(geom), st_geometrytype(geom) FROM st_read('__TEST_DIR__/world_admin.shp');
+SELECT name, st_area(geom), st_geometrytype(geom) FROM st_read('{TEST_DIR}/world_admin.shp');
 ----
 
 query III rowsort expected_result
-SELECT name, st_area(geom), st_geometrytype(geom) FROM st_readshp('__TEST_DIR__/world_admin.shp');
+SELECT name, st_area(geom), st_geometrytype(geom) FROM st_readshp('{TEST_DIR}/world_admin.shp');
 ----


### PR DESCRIPTION
CI [failed](https://github.com/duckdb/duckdb/actions/runs/26096396014/job/76735715649#step:30:71) on my duckdb [PR](https://github.com/duckdb/duckdb/pull/22498/) for deprecated lambda syntax in spatial tests:
```
1. /duckdb_build_dir/build/release/_deps/spatial_extension_fc-src/test/sql/join/spatial_join_test_3.test_slow:15
================================================================================
Query unexpectedly failed! (/duckdb_build_dir/build/release/_deps/spatial_extension_fc-src/test/sql/join/spatial_join_test_3.test_slow:15)!
================================================================================
INSERT INTO t1 SELECT
	x * 100 + y as i,
	st_makepolygon(
		st_makeline(
			list_append(
				list_prepend(
					st_point(x + 70, y),
					list_transform(
						list_sort([{u: random() * 2 * 3.14, w: (random() * 2 - 1) * 15} for _ in range(1,16)]),
						v -> st_point(x + cos(v.u) * 70 + cos(v.u) * v.w, y + sin(v.u) * 70 + sin(v.u) * v.w))
				),
				st_point(x + 70, y)
			)
		)
	) as g,
	x || ' ' || y as v
FROM generate_series(0, 1000, 100) r1(x), generate_series(0, 1000, 100) r2(y);
================================================================================
Binder Error: Deprecated lambda arrow (->) detected. Please transition to the new lambda syntax, i.e.., lambda x, i: x + i, before DuckDB's next release.
Use SET lambda_syntax='ENABLE_SINGLE_ARROW' to revert to the deprecated behavior.
For more information, see https://duckdb.org/docs/current/sql/functions/lambda.html.
PRAGMA enable_verification has been deprecated - there is no need to set this anymore
PRAGMA enable_verification has been deprecated - there is no need to set this anymore

```

For context: the CI failure in my PR could be caused by running more extension tests in duckdb's CI pipelines because I changed the autoloading logic. Before the autoloading change, many extensions tests would be skipped if they used `require x`, and now they actually run in duckdb CI.

I took the patches from duckdb's main branch and applied them as well.

Also resolved some test deprecation / warning messages because there were many in the extensions CI log on duckdb main.