### PR TITLE
Add spatial join bbox join-filter-pushdown

### DIFF
--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -16,6 +16,8 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/vector_operations/septenary_executor.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
 
 #include "spatial/util/distance_extract.hpp"
 #include "spatial/spatial_settings.hpp"
@@ -2641,19 +2643,33 @@ struct ST_DistanceWithin {
 	//------------------------------------------------------------------------------------------------------------------
 	class BindData final : public FunctionData {
 	public:
-		double distance;
+		double distance = 0.0;
 		bool is_constant = false;
 
-		explicit BindData(double distance) : distance(distance), is_constant(true) {
+		explicit BindData(double distance, bool is_constant) : distance(distance), is_constant(is_constant) {
 		}
 
 		unique_ptr<FunctionData> Copy() const override {
-			return make_uniq<BindData>(distance);
+			return make_uniq<BindData>(distance, is_constant);
 		}
 
 		bool Equals(const FunctionData &other) const override {
 			auto &other_data = other.Cast<BindData>();
 			return is_constant == other_data.is_constant && distance == other_data.distance;
+		}
+
+		static void Serialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
+		                      const ScalarFunction &function) {
+
+			const auto &bind_data = bind_data_p->Cast<BindData>();
+			serializer.WritePropertyWithDefault<bool>(100, "is_constant", bind_data.is_constant);
+			serializer.WritePropertyWithDefault(101, "distance", bind_data.distance);
+		}
+
+		static unique_ptr<FunctionData> Deserialize(Deserializer &deserializer, ScalarFunction &function) {
+			auto is_constant = deserializer.ReadPropertyWithDefault<bool>(100, "is_constant");
+			auto distance = deserializer.ReadPropertyWithDefault<double>(101, "distance");
+			return make_uniq<BindData>(distance, is_constant);
 		}
 	};
 
@@ -2667,10 +2683,10 @@ struct ST_DistanceWithin {
 
 			// Erase argument
 			Function::EraseArgument(bound_function, arguments, 2);
-			return make_uniq<BindData>(dist_value);
+			return make_uniq<BindData>(dist_value, true);
 		}
 
-		return nullptr;
+		return make_uniq<BindData>(0.0, false);
 	}
 
 	//------------------------------------------------------------------------------------------------------------------
@@ -2785,6 +2801,8 @@ struct ST_DistanceWithin {
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
 				variant.SetBind(GeoTypes::PropagateCRS<Bind>);
+				variant.SetSerialize(BindData::Serialize);
+				variant.SetDeserialize(BindData::Deserialize);
 			});
 
 			func.SetDescription(R"(

--- a/src/spatial/operators/spatial_join_logical.cpp
+++ b/src/spatial/operators/spatial_join_logical.cpp
@@ -76,7 +76,8 @@ PhysicalOperator &LogicalSpatialJoin::CreatePlan(ClientContext &context, Physica
 	auto &right = generator.CreatePlan(*children[1]);
 
 	return generator.Make<PhysicalSpatialJoin>(*this, left, right, std::move(spatial_predicate), join_type,
-	                                           estimated_cardinality, has_const_distance, const_distance);
+	                                           estimated_cardinality, has_const_distance, const_distance,
+	                                           std::move(filter_pushdown_targets));
 }
 
 void LogicalSpatialJoin::Serialize(Serializer &writer) const {

--- a/src/spatial/operators/spatial_join_logical.hpp
+++ b/src/spatial/operators/spatial_join_logical.hpp
@@ -2,6 +2,8 @@
 
 #include "duckdb/planner/operator/logical_extension_operator.hpp"
 
+#include "spatial/operators/spatial_join_physical.hpp"
+
 namespace duckdb {
 
 class LogicalSpatialJoin final : public LogicalExtensionOperator {
@@ -30,6 +32,10 @@ public:
 
 	bool has_const_distance = false;
 	double const_distance = 0.0;
+
+	//! Probe-side targets into which we push a bounding-box filter derived from the build-side R-tree.
+	//! Populated by the optimizer; not serialized (holds runtime shared_ptrs).
+	vector<SpatialJoinPushdownTarget> filter_pushdown_targets;
 
 public:
 	explicit LogicalSpatialJoin(JoinType join_type_p);

--- a/src/spatial/operators/spatial_join_optimizer.cpp
+++ b/src/spatial/operators/spatial_join_optimizer.cpp
@@ -8,9 +8,15 @@
 #include "duckdb/planner/operator/logical_any_join.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
+#include "duckdb/optimizer/join_filter_pushdown_optimizer.hpp"
+#include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/table_filter.hpp"
 
 namespace duckdb {
 
@@ -126,6 +132,69 @@ static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const uno
 	return true;
 }
 
+// Look through GEOMETRY->GEOMETRY casts down to a plain column reference
+static bool TryGetProbeColumnBinding(const Expression &expr, ColumnBinding &binding) {
+	reference<const Expression> current = expr;
+	while (current.get().GetExpressionType() == ExpressionType::OPERATOR_CAST) {
+		auto &cast = current.get().Cast<BoundCastExpression>();
+		if (cast.child->return_type.id() != LogicalTypeId::GEOMETRY) {
+			return false;
+		}
+		current = *cast.child;
+	}
+	if (current.get().GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+		return false;
+	}
+	binding = current.get().Cast<BoundColumnRefExpression>().binding;
+	return true;
+}
+
+// Set up a bbox filter pushdown into the probe-side scan(s), mirroring the hash join's JoinFilterPushdownOptimizer.
+// The build-side R-tree's bounding box is computed at runtime (in the physical operator's Finalize) and pushed as an
+// ST_Intersects_Extent expression filter, which the geometry zonemap can use to prune row groups on the probe side.
+static void SetupFilterPushdown(LogicalSpatialJoin &join) {
+	// We can only filter the probe (left) side when unmatched probe rows are dropped, i.e. for INNER and RIGHT joins.
+	// LEFT/OUTER must emit every probe row.
+	if (join.join_type != JoinType::INNER && join.join_type != JoinType::RIGHT) {
+		return;
+	}
+
+	auto &pred = join.spatial_predicate->Cast<BoundFunctionExpression>();
+
+	// The probe side is always children[0] of the (possibly flipped) predicate.
+	ColumnBinding probe_binding;
+	if (!TryGetProbeColumnBinding(*pred.children[0], probe_binding)) {
+		// Probe key is not a plain geometry column reference, cannot push down
+		return;
+	}
+
+	// Reuse the core traversal to find the LogicalGet(s) the probe column maps to (through projections, filters, etc.)
+	vector<JoinFilterPushdownColumn> columns;
+	JoinFilterPushdownColumn column;
+	column.probe_column_index = probe_binding;
+	columns.push_back(column);
+
+	vector<PushdownFilterTarget> targets;
+	JoinFilterPushdownOptimizer::GetPushdownFilterTargets(*join.children[0], std::move(columns), targets);
+
+	for (auto &target : targets) {
+		auto &get = target.get;
+		for (auto &col : target.columns) {
+			// The geometry zonemap pruning only applies to GEOMETRY columns
+			if (col.storage_type.id() != LogicalTypeId::GEOMETRY) {
+				continue;
+			}
+			if (!get.dynamic_filters) {
+				get.dynamic_filters = make_shared_ptr<DynamicTableFilterSet>();
+			}
+			SpatialJoinPushdownTarget pushdown_target;
+			pushdown_target.dynamic_filters = get.dynamic_filters;
+			pushdown_target.probe_column_index = col.probe_column_index.column_index;
+			join.filter_pushdown_targets.push_back(std::move(pushdown_target));
+		}
+	}
+}
+
 static bool TrySwapComparisonJoin(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
 	auto &op = *plan;
 
@@ -196,6 +265,9 @@ static bool TrySwapComparisonJoin(OptimizerExtensionInput &input, unique_ptr<Log
 		spatial_join->has_const_distance =
 		    ST_DWithinHelper::TryGetConstDistance(pred_func.bind_info, spatial_join->const_distance);
 	}
+
+	// Try to set up bounding-box filter pushdown into the probe-side scan(s)
+	SetupFilterPushdown(*spatial_join);
 
 	// Also take all the conditions from the comparison join and add them as filters
 	filter.expressions.clear();
@@ -303,6 +375,9 @@ static void TrySwapAnyJoin(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
 		spatial_join->has_const_distance =
 		    ST_DWithinHelper::TryGetConstDistance(pred_func.bind_info, spatial_join->const_distance);
 	}
+
+	// Try to set up bounding-box filter pushdown into the probe-side scan(s)
+	SetupFilterPushdown(*spatial_join);
 
 	if (spatial_join->join_type == JoinType::INNER && !extra_predicates.empty()) {
 		// Create a filter on top of the spatial join for the extra predicates

--- a/src/spatial/operators/spatial_join_physical.cpp
+++ b/src/spatial/operators/spatial_join_physical.cpp
@@ -579,6 +579,12 @@ public:
 
 unique_ptr<GlobalSinkState> PhysicalSpatialJoin::GetGlobalSinkState(ClientContext &context) const {
 
+	// Clear any filters previously pushed by this operator. The same physical operator can be executed multiple times
+	// (e.g. in a recursive CTE), and the build-side bounding box differs each time. Stale filters must be cleared.
+	for (auto &target : filter_pushdown_targets) {
+		target.dynamic_filters->ClearFilters(*this);
+	}
+
 	auto gstate = make_uniq<SpatialJoinGlobalState>();
 	gstate->collection =
 	    make_uniq<TupleDataCollection>(BufferManager::GetBufferManager(context), layout, MemoryTag::EXTENSION);

--- a/src/spatial/operators/spatial_join_physical.cpp
+++ b/src/spatial/operators/spatial_join_physical.cpp
@@ -12,6 +12,10 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/table_filter.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 
 #include "spatial/util/math.hpp"
@@ -118,6 +122,12 @@ public:
 
 	uint32_t Count() const {
 		return item_count;
+	}
+
+	// The bounding box covering all items in the tree (for DWithin joins this is already expanded by
+	// the constant distance, since the per-item boxes are expanded before being pushed)
+	const Box &Bounds() const {
+		return tree_box;
 	}
 
 	// Return insertion index
@@ -396,6 +406,43 @@ static unique_ptr<Expression> GetBBOXExpression(ClientContext &context, const Lo
 	return std::move(bbox_expr);
 }
 
+// Build a constant GEOMETRY value (a rectangular polygon) covering the given box by constant-folding ST_MakeEnvelope.
+// Used to construct the bounding-box filter pushed into the probe side.
+static Value MakeEnvelopeValue(ClientContext &context, const Box2D<float> &box) {
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_MakeEnvelope");
+	auto func = entry.functions.GetFunctionByArguments(
+	    context, {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE});
+
+	vector<unique_ptr<Expression>> children;
+	children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(box.min.x)));
+	children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(box.min.y)));
+	children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(box.max.x)));
+	children.push_back(make_uniq<BoundConstantExpression>(Value::DOUBLE(box.max.y)));
+
+	auto envelope_expr = make_uniq<BoundFunctionExpression>(LogicalType::GEOMETRY(), func, std::move(children), nullptr);
+
+	return ExpressionExecutor::EvaluateScalar(context, *envelope_expr);
+}
+
+// Build an `ST_Intersects_Extent(<column>, <const envelope>)` expression filter for the build-side bounding box.
+// The column is referenced as BoundReference index 0
+// - (the convention for expression filters, which are evaluated against the single filtered column).
+static unique_ptr<TableFilter> MakeBoundingBoxFilter(ClientContext &context, const Value &envelope) {
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_Intersects_Extent");
+	auto func =
+	    entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY(), LogicalType::GEOMETRY()});
+
+	vector<unique_ptr<Expression>> children;
+	children.push_back(make_uniq<BoundReferenceExpression>(LogicalType::GEOMETRY(), 0));
+	children.push_back(make_uniq<BoundConstantExpression>(envelope));
+
+	auto predicate = make_uniq<BoundFunctionExpression>(LogicalType::BOOLEAN, func, std::move(children), nullptr);
+
+	return make_uniq<ExpressionFilter>(std::move(predicate));
+}
+
 //======================================================================================================================
 // Physical Spatial Join Operator
 //======================================================================================================================
@@ -403,9 +450,11 @@ static unique_ptr<Expression> GetBBOXExpression(ClientContext &context, const Lo
 PhysicalSpatialJoin::PhysicalSpatialJoin(PhysicalPlan &physical_plan, LogicalOperator &op, PhysicalOperator &left,
                                          PhysicalOperator &right, unique_ptr<Expression> condition_p,
                                          JoinType join_type, idx_t estimated_cardinality, bool has_const_distance,
-                                         double const_distance)
+                                         double const_distance,
+                                         vector<SpatialJoinPushdownTarget> filter_pushdown_targets)
     : PhysicalJoin(physical_plan, op, PhysicalOperatorType::EXTENSION, join_type, estimated_cardinality),
-      condition(std::move(condition_p)), has_const_distance(has_const_distance), const_distance(const_distance) {
+      condition(std::move(condition_p)), has_const_distance(has_const_distance), const_distance(const_distance),
+      filter_pushdown_targets(std::move(filter_pushdown_targets)) {
 
 	children.emplace_back(left);
 	children.emplace_back(right);
@@ -756,6 +805,17 @@ SinkFinalizeType PhysicalSpatialJoin::Finalize(Pipeline &pipeline, Event &event,
 
 	// Build the R-Tree once we've gathered everything
 	gstate.rtree->Build();
+
+	// If we have probe-side targets, push down a bounding-box filter derived from the build-side R-tree.
+	// Every match requires the probe geometry's bbox to intersect some build box, which is contained in the R-tree's
+	// root box, so probe rows outside it can be pruned. For ST_DWithin the distance is already baked into the root box.
+	// (the per-item boxes were expanded before insertion).
+	if (!filter_pushdown_targets.empty() && gstate.rtree->Count() > 0) {
+		const auto envelope = MakeEnvelopeValue(context, gstate.rtree->Bounds());
+		for (auto &target : filter_pushdown_targets) {
+			target.dynamic_filters->PushFilter(*this, target.probe_column_index, MakeBoundingBoxFilter(context, envelope));
+		}
+	}
 
 	return SinkFinalizeType::READY;
 }

--- a/src/spatial/operators/spatial_join_physical.hpp
+++ b/src/spatial/operators/spatial_join_physical.hpp
@@ -5,6 +5,16 @@
 
 namespace duckdb {
 
+class DynamicTableFilterSet;
+
+//! A target into which the spatial join pushes a bounding-box filter derived from the build-side R-tree.
+struct SpatialJoinPushdownTarget {
+	//! The dynamic table filter set of the probe-side LogicalGet to push the filter into
+	shared_ptr<DynamicTableFilterSet> dynamic_filters;
+	//! The storage column index of the probe-side geometry column
+	idx_t probe_column_index;
+};
+
 class PhysicalSpatialJoin final : public PhysicalJoin {
 public:
 	static constexpr auto TYPE = PhysicalOperatorType::EXTENSION;
@@ -12,7 +22,8 @@ public:
 public:
 	PhysicalSpatialJoin(PhysicalPlan &physical_plan, LogicalOperator &op, PhysicalOperator &left,
 	                    PhysicalOperator &right, unique_ptr<Expression> spatial_predicate, JoinType join_type,
-	                    idx_t estimated_cardinality, bool has_const_distance, double const_distance);
+	                    idx_t estimated_cardinality, bool has_const_distance, double const_distance,
+	                    vector<SpatialJoinPushdownTarget> filter_pushdown_targets);
 
 	//! The condition of the join
 	unique_ptr<Expression> condition;
@@ -35,6 +46,9 @@ public:
 	// In case this is a ST_DWithin join, we store the constant distance here
 	bool has_const_distance = false;
 	double const_distance = 0.0;
+
+	// Probe-side targets into which we push a bounding-box filter derived from the build-side R-tree
+	vector<SpatialJoinPushdownTarget> filter_pushdown_targets;
 
 public:
 	// Operator Interface

--- a/test/sql/geometry/st_dwithin.test
+++ b/test/sql/geometry/st_dwithin.test
@@ -1,0 +1,48 @@
+# name: test/sql/geometry/st_dwithin.test
+# description: Test ST_DWithin, including bind-data (constant distance) serialization round-trip
+# group: [geometry]
+
+require spatial
+
+# enable_verification round-trips the plan through serialization, which exercises the
+# ST_DWithin bind-data (constant distance) serialize/deserialize callbacks
+statement ok
+PRAGMA enable_verification
+
+# Constant distance (folded into bind data)
+query I
+SELECT ST_DWithin(ST_Point(0, 0), ST_Point(3, 4), 5.0);
+----
+true
+
+query I
+SELECT ST_DWithin(ST_Point(0, 0), ST_Point(3, 4), 4.0);
+----
+false
+
+# Exact boundary
+query I
+SELECT ST_DWithin(ST_Point(0, 0), ST_Point(3, 4), 5.0) AND NOT ST_DWithin(ST_Point(0, 0), ST_Point(3, 4), 4.999);
+----
+true
+
+# Constant distance over a table (the bind-data path that previously crashed under verification)
+statement ok
+CREATE TABLE pts AS SELECT ST_Point(x, 0) AS geom, x AS d FROM range(0, 10) t(x);
+
+query I
+SELECT count(*) FROM pts WHERE ST_DWithin(geom, ST_Point(0, 0), 3.0);
+----
+4
+
+# Non-constant distance (references a column -> no bind data, distance read at execution)
+query I
+SELECT count(*) FROM pts WHERE ST_DWithin(geom, ST_Point(0, 0), d::DOUBLE);
+----
+10
+
+# NULL handling
+query I
+SELECT ST_DWithin(NULL::GEOMETRY, ST_Point(0, 0), 5.0);
+----
+NULL

--- a/test/sql/geos/geos_agg_error_handling.test
+++ b/test/sql/geos/geos_agg_error_handling.test
@@ -4,10 +4,6 @@ require spatial
 # when encountering invalid geometries. Previously, the GEOS error handler was not
 # registered for aggregate function contexts, causing nullptr dereferences.
 
-# TODO: GEOS currently has some issues on latest MSVC in release mode, so diable this test for now
-# https://github.com/libgeos/geos/issues/1449
-require notwindows
-
 # ST_Union_Agg with self-intersecting (bowtie) polygons
 statement error
 SELECT ST_Union_Agg(geom) FROM (VALUES

--- a/test/sql/geos/geos_agg_error_handling.test
+++ b/test/sql/geos/geos_agg_error_handling.test
@@ -4,6 +4,10 @@ require spatial
 # when encountering invalid geometries. Previously, the GEOS error handler was not
 # registered for aggregate function contexts, causing nullptr dereferences.
 
+# TODO: GEOS currently has some issues on latest MSVC in release mode, so diable this test for now
+# https://github.com/libgeos/geos/issues/1449
+require notwindows
+
 # ST_Union_Agg with self-intersecting (bowtie) polygons
 statement error
 SELECT ST_Union_Agg(geom) FROM (VALUES

--- a/test/sql/join/spatial_join_filter_pushdown.test
+++ b/test/sql/join/spatial_join_filter_pushdown.test
@@ -1,0 +1,104 @@
+# name: test/sql/join/spatial_join_filter_pushdown.test
+# description: Test bounding-box filter pushdown into the probe side of the spatial join
+# group: [join]
+
+require spatial
+
+statement ok
+PRAGMA enable_verification
+
+# Probe side: a 11x11 grid of points (0,0) .. (100,100)
+statement ok
+CREATE TABLE probe AS
+SELECT ST_Point(x, y) AS geom, (y * 11) + (x // 10) AS id
+FROM generate_series(0, 100, 10) r1(x), generate_series(0, 100, 10) r2(y);
+
+# Build side: a single envelope covering [20,20] .. [50,50]
+statement ok
+CREATE TABLE build AS SELECT ST_MakeEnvelope(20, 20, 50, 50) AS geom;
+
+# INNER: points inside [20,50]x[20,50] -> x in {20,30,40,50}, y in {20,30,40,50} = 16
+query I
+SELECT count(*) FROM probe, build WHERE ST_Intersects(probe.geom, build.geom);
+----
+16
+
+# INNER: filter is pushed into the probe scan
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM probe, build WHERE ST_Intersects(probe.geom, build.geom);
+----
+analyzed_plan	<REGEX>:.*st_intersects_extent.*
+
+# RIGHT: probe side can still be filtered; single build row matches 16 probe rows
+query I
+SELECT count(*) FROM probe RIGHT JOIN build ON ST_Intersects(probe.geom, build.geom);
+----
+16
+
+# RIGHT: filter is pushed into the probe scan
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM probe RIGHT JOIN build ON ST_Intersects(probe.geom, build.geom);
+----
+analyzed_plan	<REGEX>:.*st_intersects_extent.*
+
+# LEFT: every probe row must be preserved (no pushdown) -> 121
+query I
+SELECT count(*) FROM probe LEFT JOIN build ON ST_Intersects(probe.geom, build.geom);
+----
+121
+
+# LEFT: filter must NOT be pushed (probe rows must all be preserved)
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM probe LEFT JOIN build ON ST_Intersects(probe.geom, build.geom);
+----
+analyzed_plan	<!REGEX>:.*st_intersects_extent.*
+
+# FULL OUTER: every probe row preserved, build row matched -> 121
+query I
+SELECT count(*) FROM probe FULL OUTER JOIN build ON ST_Intersects(probe.geom, build.geom);
+----
+121
+
+# FULL OUTER: filter must NOT be pushed
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM probe FULL OUTER JOIN build ON ST_Intersects(probe.geom, build.geom);
+----
+analyzed_plan	<!REGEX>:.*st_intersects_extent.*
+
+# ST_DWithin with constant distance: box is expanded by the distance before pruning
+# d=10 -> 16 inside + 8 (dx=0,dy=10) + 8 (dx=10,dy=0) = 32
+query I
+SELECT count(*) FROM probe, build WHERE ST_DWithin(probe.geom, build.geom, 10.0);
+----
+32
+
+# DWithin: filter is pushed into the probe scan (box expanded by the distance)
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM probe, build WHERE ST_DWithin(probe.geom, build.geom, 10.0);
+----
+analyzed_plan	<REGEX>:.*st_intersects_extent.*
+
+# Probe key that is not a plain column reference (ST_Centroid) -> pushdown skipped, still correct
+query I
+SELECT count(*) FROM probe, build WHERE ST_Intersects(ST_Centroid(probe.geom), build.geom);
+----
+16
+
+# ST_Centroid: probe key is not a plain column reference -> filter must NOT be pushed
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM probe, build WHERE ST_Intersects(ST_Centroid(probe.geom), build.geom);
+----
+analyzed_plan	<!REGEX>:.*st_intersects_extent.*
+
+# Inverse predicate (build contains probe) -> predicate flipped, probe still filtered.
+# ST_Contains is strict, so boundary points (x or y in {20,50}) are excluded: interior is x in {30,40}, y in {30,40} = 4
+query I
+SELECT count(*) FROM probe, build WHERE ST_Contains(build.geom, probe.geom);
+----
+4
+
+# Inverse predicate: filter is still pushed into the probe scan after flipping
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM probe, build WHERE ST_Contains(build.geom, probe.geom);
+----
+analyzed_plan	<REGEX>:.*st_intersects_extent.*

--- a/test/sql/join/spatial_join_filter_pushdown_cte.test
+++ b/test/sql/join/spatial_join_filter_pushdown_cte.test
@@ -1,0 +1,22 @@
+require spatial
+
+statement ok
+CREATE TABLE probe AS
+SELECT x, ST_Point(x, 0) AS geom
+FROM (VALUES (0), (100), (200)) v(x);
+
+# The build-side bounding box changes each recursive iteration. Dynamic filters
+# pushed by the spatial join must be cleared before the next execution of the
+# same physical operator, otherwise the probe scan is filtered by stale bounds.
+query I
+WITH RECURSIVE r(i, geom) AS (
+	SELECT 0, ST_Point(0, 0)
+	UNION ALL
+	SELECT r.i + 1, p.geom
+	FROM probe p, r
+	WHERE r.i < 2
+	  AND ST_Intersects(p.geom, ST_Point((r.i + 1) * 100, 0))
+)
+SELECT count(*) FROM r;
+----
+3


### PR DESCRIPTION
...and fix ST_DistanceWithin const-serialization.

We can make the join-filter-pushdown much more advanced by pushing down the entire r-tree, but this is good enough for now and allows us to utilize stats pruning.

CC @lnkuiper, im always nervous about column binding/storage index stuff in the optimizer, does it look okay?