### PR TITLE
use local vcpkg port for geos

### DIFF
--- a/vcpkg_ports/geos/fix-exported-config.patch
+++ b/vcpkg_ports/geos/fix-exported-config.patch
@@ -1,0 +1,80 @@
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index a8c034fb2..a5cd14c13 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -61,11 +61,22 @@ function(configure_install_geos_pc)
+     set(libdir "$\{exec_prefix\}/${CMAKE_INSTALL_LIBDIR}")
+   endif()
+   set(VERSION ${GEOS_VERSION})
+-  set(EXTRA_LIBS "-lstdc++")
++  set(EXTRA_LIBS "")
++  foreach(lib IN LISTS CMAKE_CXX_IMPLICIT_LINK_LIBRARIES)
++    if(lib IN_LIST CMAKE_C_IMPLICIT_LINK_LIBRARIES)
++      continue()
++    elseif(EXISTS "${lib}")
++      list(APPEND EXTRA_LIBS "${lib}")
++    else()
++      list(APPEND EXTRA_LIBS "-l${lib}")
++    endif()
++  endforeach()
+   if(HAVE_LIBM)
++    list(REMOVE_ITEM EXTRA_LIBS "-lm")
+     list(APPEND EXTRA_LIBS "-lm")
+   endif()
+   list(JOIN EXTRA_LIBS " " EXTRA_LIBS)
++  set(EXTRA_LIBS "${EXTRA_LIBS}" PARENT_SCOPE) # for geos-config
+ 
+   configure_file(
+     ${CMAKE_CURRENT_SOURCE_DIR}/geos.pc.in
+@@ -77,9 +88,9 @@ function(configure_install_geos_pc)
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ endfunction()
+ 
++configure_install_geos_pc()
+ if(NOT MSVC)
+   configure_install_geos_config()
+-  configure_install_geos_pc()
+ endif()
+ 
+ option(BUILD_ASTYLE "Build astyle (Artistic Style) tool" OFF)
+diff --git a/tools/geos-config.in b/tools/geos-config.in
+index 6eff1eb14..8827f6ac6 100644
+--- a/tools/geos-config.in
++++ b/tools/geos-config.in
+@@ -1,9 +1,11 @@
+ #!/bin/sh
+ 
+-prefix=@prefix@
+-exec_prefix=@exec_prefix@
+-includedir=@includedir@
+-libdir=@libdir@
++DIRNAME=$(dirname $0)
++TOOLS=$(dirname $DIRNAME)
++prefix=$(CDPATH= cd -- "${DIRNAME%/tools/geos/*}" && pwd -P)
++exec_prefix=${prefix}
++includedir=${prefix}/include
++libdir=${prefix}${TOOLS##*/geos}/lib
+ 
+ usage()
+ {
+@@ -47,16 +49,16 @@ while test $# -gt 0; do
+       echo -L${libdir} -lgeos
+       ;;
+     --clibs)
+-      echo -L${libdir} -lgeos_c
++      echo -L${libdir} -lgeos_c $(if test "@BUILD_SHARED_LIBS@" != "ON"; then echo "-lgeos @EXTRA_LIBS@"; fi)
+       ;;
+     --cclibs)
+-      echo -L${libdir} -lgeos
++      echo -L${libdir} -lgeos $(if test "@BUILD_SHARED_LIBS@" != "ON"; then echo "@EXTRA_LIBS@"; fi)
+       ;;
+     --static-clibs)
+-      echo -L${libdir} -lgeos_c -lgeos -lstdc++ -lm
++      echo -L${libdir} -lgeos_c -lgeos @EXTRA_LIBS@
+       ;;
+     --static-cclibs)
+-      echo -L${libdir} -lgeos -lstdc++ -lm
++      echo -L${libdir} -lgeos @EXTRA_LIBS@
+       ;;
+     --cflags)
+       echo -I${includedir}

--- a/vcpkg_ports/geos/portfile.cmake
+++ b/vcpkg_ports/geos/portfile.cmake
@@ -1,0 +1,51 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libgeos/geos
+    REF "7db6f62d50221a7ccac91c329a9a4fe61d172a56"
+    SHA512 "989edcfd65b49f9c1e063b39ceb0bec0196dce4f3fbfebb935005a9137c918b37dd3a6e866129c2ac1bac8eacf8e1f67a9569693b98711e1d25f2096d4512518"
+    HEAD_REF main
+    PATCHES fix-exported-config.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_ASTYLE=OFF
+        -DBUILD_DOCUMENTATION=OFF
+        -DBUILD_GEOSOP=OFF
+        -DBUILD_TESTING=OFF
+        -DBUILD_BENCHMARKS=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/GEOS)
+vcpkg_fixup_pkgconfig()
+
+if(NOT VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_MINGW)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/geos-config" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/geos-config")
+    file(CHMOD "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/geos-config" FILE_PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+    )
+    if(NOT VCPKG_BUILD_TYPE)
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bin/geos-config" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/geos-config")
+        file(CHMOD "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/bin/geos-config" FILE_PERMISSIONS
+            OWNER_READ OWNER_WRITE OWNER_EXECUTE
+            GROUP_READ GROUP_EXECUTE
+            WORLD_READ WORLD_EXECUTE
+        )
+    endif()
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_copy_pdbs()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/vcpkg_ports/geos/usage
+++ b/vcpkg_ports/geos/usage
@@ -1,0 +1,14 @@
+geos provides CMake targets:
+
+  # C API (provides long-term ABI stability)
+  find_package(GEOS CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE GEOS::geos_c)
+
+  # C++ API (will likely change across versions)
+  find_package(GEOS CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE GEOS::geos)
+
+geos provides pkg-config modules:
+
+  # Geometry Engine, Open Source - C API
+  geos

--- a/vcpkg_ports/geos/vcpkg.json
+++ b/vcpkg_ports/geos/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "geos",
+  "version": "3.14.1",
+  "description": "Geometry Engine Open Source",
+  "homepage": "https://libgeos.org/",
+  "license": "LGPL-2.1-only",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
This allows us to pull in back ported fixes without having to wait for VCPKG to update. Should hopefully fix the windows issues we've encountered in v1.5.