### PR TITLE
Add relassert and re-run tests to stabilize CI

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -44,3 +44,46 @@ jobs:
       extension_name: spatial
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
       exclude_archs: 'linux_amd64_musl'
+
+  relassert:
+    name: Build relassert
+    runs-on: ${{ github.repository_owner == 'duckdb' && 'namespace-profile-linux-x64' || 'ubuntu-latest' }}
+    env:
+      GEN: ninja
+      CC: clang-20
+      CXX: clang++-20
+      # Enable -DDEBUG slow verifiers (expression verifier, operator
+      # round-trips, etc.) without changing the optimization level.
+      FORCE_DEBUG: 1
+      FORCE_ASSERT: 1
+      ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1:abort_on_error=0"
+      UBSAN_OPTIONS: "halt_on_error=1:print_stacktrace=1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+      - name: Install tools
+        run: python3 duckdb/scripts/ci/retry.py -- make -C duckdb toolsci
+      - name: Fix ASan runtime
+        # libclang_rt.asan_static.a is missing in ubuntu 24.04 — workaround
+        # mirrored from upstream Main.yml.
+        run: |
+          asan_static_dir="/usr/lib/llvm-20/lib/clang/20/lib/x86_64-pc-linux-gnu"
+          asan_static_target="/usr/lib/llvm-20/lib/clang/20/lib/linux/libclang_rt.asan_static-x86_64.a"
+          if [[ ! -e "${asan_static_dir}/libclang_rt.asan_static.a" && -e "${asan_static_target}" ]]; then
+            sudo mkdir -p "${asan_static_dir}"
+            sudo ln -sf "${asan_static_target}" "${asan_static_dir}/libclang_rt.asan_static.a"
+          fi
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          max-size: 5GB
+          evict-old-files: job
+      - name: Build (relassert → ASan + UBSan + LSan)
+        uses: duckdb/duckdb-ci/build-duckdb@main
+        with:
+          build-type: relassert
+          build: python3 duckdb/scripts/ci/retry.py -- make relassert
+          test: make unittest_relassert
+          vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,23 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=spatial
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
-T ?= --batch-size 1 --batch-timeout 300
+TEST_FLAGS:=--batch-size 1 --batch-timeout 300
+
+# Stabilize all tests in CI
+ifdef CI
+TEST_FLAGS+= --stabilize-tests
+endif
+
+T ?= $(TEST_FLAGS) "test/*"
 
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
+
+unittest_relassert:
+	build/relassert/test/run $(T)
+
 
 #### Override the included format target because we have different source tree layout
 format:
 	find src/spatial -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
 	cmake-format -i CMakeLists.txt
-
-relassert:
-	mkdir -p build/relassert
-	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) -DFORCE_ASSERT=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -S $(DUCKDB_SRCDIR) -B build/relassert
-	cmake --build build/relassert

--- a/src/spatial/index/rtree/rtree_index.cpp
+++ b/src/spatial/index/rtree/rtree_index.cpp
@@ -112,7 +112,8 @@ RTreeIndex::RTreeIndex(const Identifier &name, IndexConstraintType index_constra
 	// Construct the key expression executor
 	auto &source_type = unbound_expressions[0]->GetReturnType();
 	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "ST_Extent_Approx");
+	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "ST_Extent_Approx"));
 	const auto &func = entry.functions.GetFunctionByArguments(context, {source_type});
 	auto child_expr = make_uniq<BoundReferenceExpression>(source_type, 0);
 

--- a/src/spatial/index/rtree/rtree_index_create_logical.cpp
+++ b/src/spatial/index/rtree/rtree_index_create_logical.cpp
@@ -290,10 +290,10 @@ unique_ptr<LogicalExtensionOperator> LogicalCreateRTreeIndex::Deserialize(Deseri
 
 	// We also need to rebind the table
 	auto &context = reader.Get<ClientContext &>();
-	const auto &catalog = info->Catalog();
-	const auto &schema = info->Schema();
+	const auto &catalog = info->GetQualifiedName().Catalog();
+	const auto &schema = info->GetQualifiedName().Schema();
 	const auto &table_name = info->table;
-	auto &table_entry = Catalog::GetEntry<TableCatalogEntry>(context, catalog, schema, table_name);
+	auto &table_entry = Catalog::GetEntry<TableCatalogEntry>(context, QualifiedName(catalog, schema, table_name));
 
 	// Return the new operator
 	return make_uniq_base<LogicalExtensionOperator, LogicalCreateRTreeIndex>(

--- a/src/spatial/index/rtree/rtree_index_create_logical.cpp
+++ b/src/spatial/index/rtree/rtree_index_create_logical.cpp
@@ -290,8 +290,8 @@ unique_ptr<LogicalExtensionOperator> LogicalCreateRTreeIndex::Deserialize(Deseri
 
 	// We also need to rebind the table
 	auto &context = reader.Get<ClientContext &>();
-	const auto &catalog = info->catalog;
-	const auto &schema = info->schema;
+	const auto &catalog = info->Catalog();
+	const auto &schema = info->Schema();
 	const auto &table_name = info->table;
 	auto &table_entry = Catalog::GetEntry<TableCatalogEntry>(context, catalog, schema, table_name);
 

--- a/src/spatial/index/rtree/rtree_index_create_physical.cpp
+++ b/src/spatial/index/rtree/rtree_index_create_physical.cpp
@@ -79,7 +79,7 @@ unique_ptr<GlobalSinkState> PhysicalCreateRTreeIndex::GetGlobalSinkState(ClientC
 	auto &constraint_type = info->constraint_type;
 	auto &db = storage.db;
 	gstate->rtree =
-	    make_uniq<RTreeIndex>(Identifier(info->index_name.GetIdentifierName()), constraint_type, storage_ids, table_manager, unbound_expressions, db,
+	    make_uniq<RTreeIndex>(Identifier(info->GetIndexName().GetIdentifierName()), constraint_type, storage_ids, table_manager, unbound_expressions, db,
 	                          info->options, context, IndexStorageInfo(), estimated_cardinality);
 
 	gstate->max_node_capacity = gstate->rtree->tree->GetConfig().max_node_capacity;
@@ -284,9 +284,9 @@ static void AddIndexToCatalog(ClientContext &context, CreateRTreeIndexGlobalStat
 	// Create the index entry in the catalog
 	auto &schema = table.schema;
 
-	if (schema.GetEntry(schema.GetCatalogTransaction(context), CatalogType::INDEX_ENTRY, info.index_name)) {
+	if (schema.GetEntry(schema.GetCatalogTransaction(context), CatalogType::INDEX_ENTRY, info.GetIndexName())) {
 		if (info.on_conflict != OnCreateConflict::IGNORE_ON_CONFLICT) {
-			throw CatalogException("Index with name \"%s\" already exists", info.index_name);
+			throw CatalogException("Index with name \"%s\" already exists", info.GetIndexName());
 		}
 		// IF NOT EXISTS on existing index. We are done.
 		// TODO: Early out before this.

--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
@@ -120,7 +120,8 @@ public:
 
 		// make a new box expression
 		auto &catalog = Catalog::GetSystemCatalog(context);
-		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "ST_Extent_Approx");
+		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+		    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "ST_Extent_Approx"));
 		const auto &func = entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
 
 		vector<unique_ptr<Expression>> children;
@@ -236,8 +237,7 @@ public:
 			bool rewrite_possible = true;
 			auto index_expr = index_entry.unbound_expressions[0]->Copy();
 			if (filter_column_idx) {
-				RewriteIndexExpressionForFilter(index_entry, get, index_expr, *filter_column_idx,
-				                                rewrite_possible);
+				RewriteIndexExpressionForFilter(index_entry, get, index_expr, *filter_column_idx, rewrite_possible);
 			} else {
 				RewriteIndexExpression(index_entry, get, *index_expr, rewrite_possible);
 			}

--- a/src/spatial/index/rtree/rtree_index_pragmas.cpp
+++ b/src/spatial/index/rtree/rtree_index_pragmas.cpp
@@ -110,10 +110,10 @@ static optional_ptr<RTreeIndex> TryGetIndex(ClientContext &context, const string
 	auto qname = QualifiedName::Parse(index_name);
 
 	// look up the index name in the catalog
-	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
-	auto &index_entry = Catalog::GetEntry(context, CatalogType::INDEX_ENTRY, qname.catalog, qname.schema, qname.name)
+	Binder::BindSchemaOrCatalog(context, qname.CatalogMutable(), qname.SchemaMutable());
+	auto &index_entry = Catalog::GetEntry(context, CatalogType::INDEX_ENTRY, qname.Catalog(), qname.Schema(), qname.Name())
 	                        .Cast<IndexCatalogEntry>();
-	auto &table_entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.catalog,
+	auto &table_entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.Catalog(),
 	                                      index_entry.GetSchemaName(),
 	                                      index_entry.GetTableName())
 	                        .Cast<TableCatalogEntry>();

--- a/src/spatial/index/rtree/rtree_index_pragmas.cpp
+++ b/src/spatial/index/rtree/rtree_index_pragmas.cpp
@@ -73,7 +73,8 @@ static void RTreeIndexInfoExecute(ClientContext &context, TableFunctionInput &da
 	while (data.offset < data.entries.size() && row < STANDARD_VECTOR_SIZE) {
 		auto &index_entry = data.entries[data.offset++].get();
 		auto &table_entry = index_entry.schema.catalog.GetEntry<TableCatalogEntry>(
-		    context, index_entry.GetSchemaName(), index_entry.GetTableName());
+		    context, QualifiedName(index_entry.schema.catalog.GetName(), index_entry.GetSchemaName(),
+		                           index_entry.GetTableName()));
 		auto &storage = table_entry.GetStorage();
 		RTreeIndex *rtree_index = nullptr;
 
@@ -110,12 +111,12 @@ static optional_ptr<RTreeIndex> TryGetIndex(ClientContext &context, const string
 	auto qname = QualifiedName::Parse(index_name);
 
 	// look up the index name in the catalog
-	Binder::BindSchemaOrCatalog(context, qname.CatalogMutable(), qname.SchemaMutable());
-	auto &index_entry = Catalog::GetEntry(context, CatalogType::INDEX_ENTRY, qname.Catalog(), qname.Schema(), qname.Name())
-	                        .Cast<IndexCatalogEntry>();
+	Binder::BindSchemaOrCatalog(context, qname);
+	auto &index_entry =
+	    Catalog::GetEntry(context, CatalogType::INDEX_ENTRY, qname.Catalog(), qname.Schema(), qname.Name())
+	        .Cast<IndexCatalogEntry>();
 	auto &table_entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.Catalog(),
-	                                      index_entry.GetSchemaName(),
-	                                      index_entry.GetTableName())
+	                                      index_entry.GetSchemaName(), index_entry.GetTableName())
 	                        .Cast<TableCatalogEntry>();
 
 	auto &storage = table_entry.GetStorage();

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -893,13 +893,17 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data, 
 class GlobalState final : public GlobalTableFunctionState {
 public:
 	~GlobalState() override {
+		if (stream.release) {
+			stream.release(&stream);
+		}
+
+		if (schema.release) {
+			schema.release(&schema);
+		}
+
 		if (dataset) {
 			GDALClose(dataset);
 			dataset = nullptr;
-		}
-
-		if (stream.release) {
-			stream.release(&stream);
 		}
 	}
 
@@ -907,6 +911,7 @@ public:
 	CPLStringList layer_options;
 	OGRLayerH layer;
 	ArrowArrayStream stream;
+	ArrowSchema schema;
 	vector<unique_ptr<ArrowType>> col_types;
 	atomic<idx_t> features_read = {0};
 };
@@ -959,20 +964,16 @@ auto InitGlobal(ClientContext &context, TableFunctionInitInput &input) -> unique
 
 	// Open the Arrow stream
 	if (!OGR_L_GetArrowStream(result->layer, &result->stream, result->layer_options.List())) {
-		GDALClose(dataset);
 		throw IOException("Could not get GDAL Arrow stream");
 	}
 
-	ArrowSchema schema;
-	if (result->stream.get_schema(&result->stream, &schema) != 0) {
-		result->stream.release(&result->stream);
-		GDALClose(dataset);
+	if (result->stream.get_schema(&result->stream, &result->schema) != 0) {
 		throw IOException("Could not get GDAL Arrow schema");
 	}
 
 	// Store the column types
-	for (int64_t i = 0; i < schema.n_children; i++) {
-		auto &child_schema = *schema.children[i];
+	for (int64_t i = 0; i < result->schema.n_children; i++) {
+		auto &child_schema = *result->schema.children[i];
 		result->col_types.push_back(ArrowType::GetTypeFromSchema(context, child_schema));
 	}
 

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -17,6 +17,8 @@
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
 
+#include <utility>
+
 // GDAL
 #include "gdal.h"
 #include "ogr_core.h"
@@ -24,6 +26,7 @@
 #include "ogr_srs_api.h"
 #include "ogrsf_frmts.h"
 #include "cpl_string.h"
+#include "cpl_error.h"
 #include "cpl_vsi.h"
 #include "cpl_vsi_error.h"
 #include "cpl_vsi_virtual.h"
@@ -38,6 +41,86 @@ namespace duckdb {
 namespace {
 
 //======================================================================================================================
+// GDAL Error Handling
+//======================================================================================================================
+// GDAL's internals are not exception-safe: throwing a C++ exception from a CPLErrorHandler (or a VSI callback) unwinds
+// through GDAL's own C/C++ frames and leaks heap allocations that would otherwise be freed on the normal return path.
+// Instead we install a non-throwing handler that just silences GDAL's default stderr output, and inspect GDAL's
+// thread-local error state at our own call boundaries.
+
+// Map GDAL's thread-local last-error state to a DuckDB exception and throw it. Call this only once a GDAL call has
+// already reported failure through its return value. `fallback` is used when GDAL recorded no fresh failure of its own.
+// We reset GDAL's error state before throwing so a recovered/stale error can't leak onto the next call on this thread.
+
+// Parse the DuckDB message part out of a raw GDAL message (GDAL re-reports caught exceptions as CPLE_AppDefined) and
+// strip any /vsiduckdb-<uuid>/ prefix to make the error more readable when we print file paths.
+string CleanGDALMessage(const char *raw_msg) {
+	ErrorData error_data(raw_msg);
+	auto msg = error_data.RawMessage();
+	const auto path_pos = msg.find("/vsiduckdb-");
+	if (path_pos != string::npos) {
+		msg.erase(path_pos, 48);
+	}
+	return msg;
+}
+
+[[noreturn]] void ThrowGDALError(const string &fallback) {
+
+	// If GDAL didn't report a fresh error, but we still want to throw, use the fallback message on its own.
+	if (CPLGetLastErrorType() < CE_Failure) {
+		CPLErrorReset();
+		throw IOException(fallback);
+	}
+
+	const auto code = CPLGetLastErrorNo();
+
+	auto msg = CleanGDALMessage(CPLGetLastErrorMsg());
+	if (msg.empty()) {
+		msg = fallback;
+	}
+
+	// Reset GDAL's error state before throwing so a recovered/stale error can't leak onto the next call on this thread.
+	CPLErrorReset();
+
+	switch (code) {
+	case CPLE_NoWriteAccess:
+		throw PermissionException(msg);
+	case CPLE_UserInterrupt:
+		throw InterruptException();
+	case CPLE_OutOfMemory:
+		throw OutOfMemoryException(msg);
+	case CPLE_NotSupported:
+		throw NotImplementedException(msg);
+	case CPLE_AssertionFailed:
+	case CPLE_ObjectNull:
+		throw InternalException(msg);
+	case CPLE_IllegalArg:
+		throw InvalidInputException(msg);
+	case CPLE_AppDefined:
+	case CPLE_HttpResponse:
+	case CPLE_FileIO:
+	case CPLE_OpenFailed:
+	default:
+		throw IOException(msg);
+	}
+}
+
+// Run a DuckDB FileSystem operation from within a GDAL VSI callback, converting any C++ exception into a VSI error plus
+// the given error return value. Exceptions must never cross the C VSI boundary
+template <class FUNC>
+auto VSIGuard(FUNC &&func, decltype(std::declval<FUNC &>()()) error_value) -> decltype(std::declval<FUNC &>()()) {
+	try {
+		return func();
+	} catch (std::exception &ex) {
+		VSIError(VSIE_FileError, "%s", CleanGDALMessage(ex.what()).c_str());
+		return error_value;
+	} catch (...) {
+		VSIError(VSIE_FileError, "Unknown error in GDAL VSI callback");
+		return error_value;
+	}
+}
+
+//======================================================================================================================
 // GDAL FILE
 //======================================================================================================================
 class DuckDBFileHandle final : public VSIVirtualHandle {
@@ -47,33 +130,38 @@ public:
 	}
 
 	vsi_l_offset Tell() override {
-		return static_cast<vsi_l_offset>(file_handle->SeekPosition());
+		return VSIGuard([&]() -> vsi_l_offset { return static_cast<vsi_l_offset>(file_handle->SeekPosition()); },
+		                static_cast<vsi_l_offset>(-1));
 	}
 
 	int Seek(vsi_l_offset nOffset, int nWhence) override {
-		// Reset EOF flag on seek
-		is_eof = false;
+		return VSIGuard(
+		    [&]() -> int {
+			    // Reset EOF flag on seek
+			    is_eof = false;
 
-		// Use the reset function instead to allow compressed file handles to rewind
-		// even if they don't support seeking
-		if (nWhence == SEEK_SET && nOffset == 0) {
-			file_handle->Reset();
-			return 0;
-		}
+			    // Use the reset function instead to allow compressed file handles to rewind
+			    // even if they don't support seeking
+			    if (nWhence == SEEK_SET && nOffset == 0) {
+				    file_handle->Reset();
+				    return 0;
+			    }
 
-		switch (nWhence) {
-		case SEEK_SET:
-			file_handle->Seek(nOffset);
-			return 0;
-		case SEEK_CUR:
-			file_handle->Seek(file_handle->SeekPosition() + nOffset);
-			return 0;
-		case SEEK_END:
-			file_handle->Seek(file_handle->GetFileSize() + nOffset);
-			return 0;
-		default:
-			return -1;
-		}
+			    switch (nWhence) {
+			    case SEEK_SET:
+				    file_handle->Seek(nOffset);
+				    return 0;
+			    case SEEK_CUR:
+				    file_handle->Seek(file_handle->SeekPosition() + nOffset);
+				    return 0;
+			    case SEEK_END:
+				    file_handle->Seek(file_handle->GetFileSize() + nOffset);
+				    return 0;
+			    default:
+				    return -1;
+			    }
+		    },
+		    -1);
 	}
 
 	size_t Read(void *buffer, size_t size, size_t count) override {
@@ -90,18 +178,17 @@ public:
 				bytes_left -= bytes_read;
 				bytes_data += bytes_read;
 			}
-		} catch (...) {
-			if (bytes_left != 0) {
-				if (file_handle->SeekPosition() == file_handle->GetFileSize()) {
-					// Is at EOF!
-					is_eof = true;
-				}
+		} catch (std::exception &ex) {
+			// Never let the exception cross into GDAL (it is not exception-safe). A clean EOF is reported as EOF;
+			// otherwise record a VSI error and return the partial count. Note: GDAL 3.8.5 can't distinguish a short
+			// read from an error (fixed in 3.9.2), so a real error here may be observed as EOF by the caller.
+			if (file_handle->SeekPosition() == file_handle->GetFileSize()) {
+				is_eof = true;
 			} else {
-				// else, error!
-				// unfortunately, this version of GDAL cant distinguish between errors and reading less bytes
-				// its avaiable in 3.9.2, but we're stuck on 3.8.5 for now.
-				throw;
+				VSIError(VSIE_FileError, "%s", CleanGDALMessage(ex.what()).c_str());
 			}
+		} catch (...) {
+			VSIError(VSIE_FileError, "Unknown error reading file");
 		}
 
 		return count - (bytes_left / size);
@@ -115,23 +202,37 @@ public:
 		size_t written_bytes = 0;
 		try {
 			written_bytes = file_handle->Write(const_cast<void *>(buffer), size * count);
+		} catch (std::exception &ex) {
+			VSIError(VSIE_FileError, "%s", CleanGDALMessage(ex.what()).c_str());
 		} catch (...) {
-			// ignore
+			VSIError(VSIE_FileError, "Unknown error writing file");
 		}
 		return written_bytes / size;
 	}
 
 	int Flush() override {
-		file_handle->Sync();
-		return 0;
+		return VSIGuard(
+		    [&]() -> int {
+			    file_handle->Sync();
+			    return 0;
+		    },
+		    -1);
 	}
 	int Truncate(vsi_l_offset nNewSize) override {
-		file_handle->Truncate(static_cast<int64_t>(nNewSize));
-		return 0;
+		return VSIGuard(
+		    [&]() -> int {
+			    file_handle->Truncate(static_cast<int64_t>(nNewSize));
+			    return 0;
+		    },
+		    -1);
 	}
 	int Close() override {
-		file_handle->Close();
-		return 0;
+		return VSIGuard(
+		    [&]() -> int {
+			    file_handle->Close();
+			    return 0;
+		    },
+		    -1);
 	}
 
 private:
@@ -195,7 +296,8 @@ public:
 				flags |= FileFlags::FILE_FLAGS_READ;
 			}
 		} else {
-			throw InternalException("Unknown file access type");
+			VSIError(VSIE_FileError, "Unknown file access type: %s", access);
+			return nullptr;
 		}
 
 		try {
@@ -236,69 +338,73 @@ public:
 	}
 
 	int Stat(const char *gdal_file_name, VSIStatBufL *result, int n_flags) override {
-		auto real_file_path = StripPrefix(gdal_file_name);
-		auto &fs = FileSystem::GetFileSystem(context);
+		return VSIGuard(
+		    [&]() -> int {
+			    auto real_file_path = StripPrefix(gdal_file_name);
+			    auto &fs = FileSystem::GetFileSystem(context);
 
-		memset(result, 0, sizeof(VSIStatBufL));
+			    memset(result, 0, sizeof(VSIStatBufL));
 
-		if (fs.IsPipe(real_file_path)) {
-			result->st_mode = S_IFCHR;
-			return 0;
-		}
+			    if (fs.IsPipe(real_file_path)) {
+				    result->st_mode = S_IFCHR;
+				    return 0;
+			    }
 
-		if (!(fs.FileExists(real_file_path) ||
-		      (!FileSystem::IsRemoteFile(real_file_path) && fs.DirectoryExists(real_file_path)))) {
-			return -1;
-		}
+			    if (!(fs.FileExists(real_file_path) ||
+			          (!FileSystem::IsRemoteFile(real_file_path) && fs.DirectoryExists(real_file_path)))) {
+				    return -1;
+			    }
 
 #ifdef _WIN32
-		if (!FileSystem::IsRemoteFile(real_file_path) && fs.DirectoryExists(real_file_path)) {
-			result->st_mode = S_IFDIR;
-			return 0;
-		}
+			    if (!FileSystem::IsRemoteFile(real_file_path) && fs.DirectoryExists(real_file_path)) {
+				    result->st_mode = S_IFDIR;
+				    return 0;
+			    }
 #endif
 
-		FileOpenFlags flags;
-		flags |= FileFlags::FILE_FLAGS_READ;
-		flags |= FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
-		flags |= FileCompressionType::AUTO_DETECT;
+			    FileOpenFlags flags;
+			    flags |= FileFlags::FILE_FLAGS_READ;
+			    flags |= FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
+			    flags |= FileCompressionType::AUTO_DETECT;
 
-		const auto file = fs.OpenFile(real_file_path, flags);
-		if (!file) {
-			return -1;
-		}
+			    const auto file = fs.OpenFile(real_file_path, flags);
+			    if (!file) {
+				    return -1;
+			    }
 
-		try {
-			result->st_size = static_cast<off_t>(fs.GetFileSize(*file));
-		} catch (...) {
-		}
-		try {
-			result->st_mtime = Timestamp::ToTimeT(fs.GetLastModifiedTime(*file));
-		} catch (...) {
-		}
-		try {
-			const auto type = file->GetType();
-			switch (type) {
-			case FileType::FILE_TYPE_REGULAR:
-				result->st_mode = S_IFREG;
-				break;
-			case FileType::FILE_TYPE_DIR:
-				result->st_mode = S_IFDIR;
-				break;
-			case FileType::FILE_TYPE_CHARDEV:
-				result->st_mode = S_IFCHR;
-				break;
-			default:
-				// HTTPFS returns invalid type for everything basically.
-				if (FileSystem::IsRemoteFile(real_file_path)) {
-					result->st_mode = S_IFREG;
-				} else {
-					return -1;
-				}
-			}
-		} catch (...) {
-		}
-		return 0;
+			    try {
+				    result->st_size = static_cast<off_t>(fs.GetFileSize(*file));
+			    } catch (...) {
+			    }
+			    try {
+				    result->st_mtime = Timestamp::ToTimeT(fs.GetLastModifiedTime(*file));
+			    } catch (...) {
+			    }
+			    try {
+				    const auto type = file->GetType();
+				    switch (type) {
+				    case FileType::FILE_TYPE_REGULAR:
+					    result->st_mode = S_IFREG;
+					    break;
+				    case FileType::FILE_TYPE_DIR:
+					    result->st_mode = S_IFDIR;
+					    break;
+				    case FileType::FILE_TYPE_CHARDEV:
+					    result->st_mode = S_IFCHR;
+					    break;
+				    default:
+					    // HTTPFS returns invalid type for everything basically.
+					    if (FileSystem::IsRemoteFile(real_file_path)) {
+						    result->st_mode = S_IFREG;
+					    } else {
+						    return -1;
+					    }
+				    }
+			    } catch (...) {
+			    }
+			    return 0;
+		    },
+		    -1);
 	}
 
 	bool IsLocal(const char *gdal_file_path) override {
@@ -307,66 +413,86 @@ public:
 	}
 
 	int Mkdir(const char *pszDirname, long nMode) override {
-		auto &fs = FileSystem::GetFileSystem(context);
-		const auto dir_name = StripPrefix(pszDirname);
+		return VSIGuard(
+		    [&]() -> int {
+			    auto &fs = FileSystem::GetFileSystem(context);
+			    const auto dir_name = StripPrefix(pszDirname);
 
-		fs.CreateDirectory(dir_name);
-		return 0;
+			    fs.CreateDirectory(dir_name);
+			    return 0;
+		    },
+		    -1);
 	}
 
 	int Rmdir(const char *pszDirname) override {
-		auto &fs = FileSystem::GetFileSystem(context);
-		const auto dir_name = StripPrefix(pszDirname);
+		return VSIGuard(
+		    [&]() -> int {
+			    auto &fs = FileSystem::GetFileSystem(context);
+			    const auto dir_name = StripPrefix(pszDirname);
 
-		fs.RemoveDirectory(dir_name);
-		return 0;
+			    fs.RemoveDirectory(dir_name);
+			    return 0;
+		    },
+		    -1);
 	}
 
 	int RmdirRecursive(const char *pszDirname) override {
-		auto &fs = FileSystem::GetFileSystem(context);
-		const auto dir_name = StripPrefix(pszDirname);
+		return VSIGuard(
+		    [&]() -> int {
+			    auto &fs = FileSystem::GetFileSystem(context);
+			    const auto dir_name = StripPrefix(pszDirname);
 
-		fs.RemoveDirectory(dir_name);
-		return 0;
+			    fs.RemoveDirectory(dir_name);
+			    return 0;
+		    },
+		    -1);
 	}
 
 	char **ReadDirEx(const char *gdal_dir_name, int max_files) override {
-		auto &fs = FileSystem::GetFileSystem(context);
-		const auto dir_name = StripPrefix(gdal_dir_name);
+		return VSIGuard(
+		    [&]() -> char ** {
+			    auto &fs = FileSystem::GetFileSystem(context);
+			    const auto dir_name = StripPrefix(gdal_dir_name);
 
-		CPLStringList files;
-		auto files_count = 0;
-		fs.ListFiles(dir_name, [&](const string &file_name, bool is_dir) {
-			if (files_count >= max_files) {
-				return;
-			}
-			const auto tmp = AddPrefix(file_name);
-			files.AddString(tmp.c_str());
-			files_count++;
-		});
-		return files.StealList();
+			    CPLStringList files;
+			    auto files_count = 0;
+			    fs.ListFiles(dir_name, [&](const string &file_name, bool is_dir) {
+				    if (files_count >= max_files) {
+					    return;
+				    }
+				    const auto tmp = AddPrefix(file_name);
+				    files.AddString(tmp.c_str());
+				    files_count++;
+			    });
+			    return files.StealList();
+		    },
+		    nullptr);
 	}
 
 	char **SiblingFiles(const char *gdal_file_path) override {
-		auto &fs = FileSystem::GetFileSystem(context);
+		return VSIGuard(
+		    [&]() -> char ** {
+			    auto &fs = FileSystem::GetFileSystem(context);
 
-		const auto real_file_path = StripPrefix(gdal_file_path);
+			    const auto real_file_path = StripPrefix(gdal_file_path);
 
-		const auto real_file_stem = StringUtil::GetFileStem(real_file_path);
-		const auto base_file_path = fs.JoinPath(StringUtil::GetFilePath(real_file_path), real_file_stem);
-		const auto glob_file_path = base_file_path + ".*";
+			    const auto real_file_stem = StringUtil::GetFileStem(real_file_path);
+			    const auto base_file_path = fs.JoinPath(StringUtil::GetFilePath(real_file_path), real_file_stem);
+			    const auto glob_file_path = base_file_path + ".*";
 
-		if (fs.IsRemoteFile(base_file_path)) {
-			// Sibling file listing is expensive for remote files, so avoid it here.
-			// GDAL will fall back to a ReadDir if needed.
-			return nullptr;
-		}
+			    if (fs.IsRemoteFile(base_file_path)) {
+				    // Sibling file listing is expensive for remote files, so avoid it here.
+				    // GDAL will fall back to a ReadDir if needed.
+				    return nullptr;
+			    }
 
-		CPLStringList files;
-		for (auto &file : fs.Glob(glob_file_path)) {
-			files.AddString(AddPrefix(file.path).c_str());
-		}
-		return files.StealList();
+			    CPLStringList files;
+			    for (auto &file : fs.Glob(glob_file_path)) {
+				    files.AddString(AddPrefix(file.path).c_str());
+			    }
+			    return files.StealList();
+		    },
+		    nullptr);
 	}
 
 	int HasOptimizedReadMultiRange(const char *pszPath) override {
@@ -467,8 +593,8 @@ public:
 		// If the path is a GDAL driver-prefixed URL (e.g., "WFS:https://..."), pass it through directly
 		if (IsGDALDriverPrefixedURL(value)) {
 			if (!Settings::Get<EnableExternalAccessSetting>(context)) {
-				throw PermissionException(
-				    "Cannot open file '%s' with GDAL driver prefix: External access is disabled", value);
+				throw PermissionException("Cannot open file '%s' with GDAL driver prefix: External access is disabled",
+				                          value);
 			}
 			return value;
 		}
@@ -575,7 +701,7 @@ auto Bind(ClientContext &ctx, TableFunctionBindInput &input, vector<LogicalType>
 	                                result->dataset_drivers, result->dataset_options, result->dataset_sibling);
 
 	if (!dataset) {
-		throw IOException("Could not open GDAL dataset at: %s", result->real_file_path);
+		ThrowGDALError(StringUtil::Format("Could not open GDAL dataset at: %s", result->real_file_path));
 	}
 
 	ArrowSchema schema;
@@ -659,7 +785,7 @@ auto Bind(ClientContext &ctx, TableFunctionBindInput &input, vector<LogicalType>
 
 		// Get the arrow stream
 		if (!OGR_L_GetArrowStream(layer, &stream, result->layer_options.List())) {
-			throw IOException("Could not get GDAL Arrow stream at: %s", result->real_file_path);
+			ThrowGDALError(StringUtil::Format("Could not get GDAL Arrow stream at: %s", result->real_file_path));
 		}
 
 		// And the schema
@@ -923,7 +1049,7 @@ auto InitGlobal(ClientContext &context, TableFunctionInitInput &input) -> unique
 	                                bdata.dataset_drivers, bdata.dataset_options, bdata.dataset_sibling);
 
 	if (!dataset) {
-		throw IOException("Could not open GDAL dataset at: %s", bdata.real_file_path);
+		ThrowGDALError(StringUtil::Format("Could not open GDAL dataset at: %s", bdata.real_file_path));
 	}
 
 	auto result = make_uniq<GlobalState>();
@@ -964,7 +1090,7 @@ auto InitGlobal(ClientContext &context, TableFunctionInitInput &input) -> unique
 
 	// Open the Arrow stream
 	if (!OGR_L_GetArrowStream(result->layer, &result->stream, result->layer_options.List())) {
-		throw IOException("Could not get GDAL Arrow stream");
+		ThrowGDALError("Could not get GDAL Arrow stream");
 	}
 
 	if (result->stream.get_schema(&result->stream, &result->schema) != 0) {
@@ -1262,8 +1388,8 @@ public:
 	BindData(BindData &&other) noexcept
 	    : driver_name(std::move(other.driver_name)), layer_name(std::move(other.layer_name)),
 	      driver_options(std::move(other.driver_options)), layer_options(std::move(other.layer_options)),
-	      target_srs(std::move(other.target_srs)), always_xy(other.always_xy),
-	      geometry_type(other.geometry_type), props(std::move(other.props)), schema(other.schema),
+	      target_srs(std::move(other.target_srs)), always_xy(other.always_xy), geometry_type(other.geometry_type),
+	      props(std::move(other.props)), schema(other.schema),
 	      extension_type_cast(std::move(other.extension_type_cast)) {
 		other.schema.release = nullptr;
 	}
@@ -1454,7 +1580,6 @@ auto Bind(ClientContext &context, CopyFunctionBindInput &input, const vector<Ide
 //----------------------------------------------------------------------------------------------------------------------
 class GlobalState final : public GlobalFunctionData {
 public:
-
 	GlobalState() {
 		dataset = nullptr;
 		layer = nullptr;
@@ -1462,8 +1587,7 @@ public:
 	}
 
 	// Move constructor
-	GlobalState(GlobalState &&other) noexcept
-	    : dataset(other.dataset), layer(other.layer), srs(other.srs) {
+	GlobalState(GlobalState &&other) noexcept : dataset(other.dataset), layer(other.layer), srs(other.srs) {
 		other.dataset = nullptr;
 		other.layer = nullptr;
 		other.srs = nullptr;
@@ -1510,7 +1634,7 @@ auto InitGlobal(ClientContext &context, FunctionData &bdata_p, const string &rea
 	// Create Dataset
 	result->dataset = GDALCreate(driver, gdal_file_path.c_str(), 0, 0, 0, GDT_Unknown, bdata.driver_options);
 	if (!result->dataset) {
-		throw IOException("Could not create GDAL dataset at: " + real_file_path);
+		ThrowGDALError("Could not create GDAL dataset at: " + real_file_path);
 	}
 
 	if (!bdata.target_srs.empty()) {
@@ -1551,7 +1675,7 @@ auto InitGlobal(ClientContext &context, FunctionData &bdata_p, const string &rea
 	                                       bdata.layer_options);
 
 	if (!result->layer) {
-		throw IOException("Could not create GDAL layer in dataset at: " + real_file_path);
+		ThrowGDALError("Could not create GDAL layer in dataset at: " + real_file_path);
 	}
 
 	// Create fields for all children
@@ -1577,7 +1701,7 @@ auto InitGlobal(ClientContext &context, FunctionData &bdata_p, const string &rea
 
 		// Register normal attribute
 		if (!OGR_L_CreateFieldFromArrowSchema(result->layer, child_schema, nullptr)) {
-			throw IOException("Could not create field in GDAL layer for column: " + string(child_schema->name));
+			ThrowGDALError("Could not create field in GDAL layer for column: " + string(child_schema->name));
 		}
 	}
 
@@ -1589,7 +1713,6 @@ auto InitGlobal(ClientContext &context, FunctionData &bdata_p, const string &rea
 //----------------------------------------------------------------------------------------------------------------------
 class LocalState final : public LocalFunctionData {
 public:
-
 	LocalState() {
 		array.release = nullptr;
 	}
@@ -1640,8 +1763,9 @@ void Sink(ExecutionContext &context, FunctionData &bdata_p, GlobalFunctionData &
 		// Lock
 		lock_guard<mutex> guard(gstate.lock);
 
-		// Sink into GDAL
-		OGR_L_WriteArrowBatch(gstate.layer, &arrow_schema, &arrow_array, nullptr);
+		if (!OGR_L_WriteArrowBatch(gstate.layer, &arrow_schema, &arrow_array, nullptr)) {
+			ThrowGDALError("Could not write Arrow batch to GDAL layer");
+		}
 	}
 
 	// Release the array
@@ -1665,10 +1789,18 @@ void Combine(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionD
 void Finalize(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate_p) {
 	auto &gstate = gstate_p.Cast<GlobalState>();
 
-	// Flush and close the dataset
-	GDALFlushCache(gstate.dataset);
-	GDALClose(gstate.dataset);
+	// Flush and close the dataset. If a flush fails we leave gstate.dataset set so the GlobalState destructor still
+	// closes it during unwinding.
+	if (GDALFlushCache(gstate.dataset) != CE_None) {
+		ThrowGDALError("Could not flush GDAL dataset");
+	}
+
+	// GDALClose frees the dataset even on error, so clear the handle before checking to avoid a double close.
+	const auto close_err = GDALClose(gstate.dataset);
 	gstate.dataset = nullptr;
+	if (close_err != CE_None) {
+		ThrowGDALError("Could not close GDAL dataset");
+	}
 }
 
 CopyFunctionExecutionMode Mode(bool preserve_insertion_order, bool use_batch_index) {
@@ -1893,8 +2025,7 @@ auto Bind(ClientContext &context, TableFunctionBindInput &input, vector<LogicalT
 	auto &input_val = input.inputs[0];
 	if (input_val.type().id() == LogicalTypeId::VARCHAR) {
 		auto raw_path = input_val.GetValue<string>();
-		if (StringUtil::StartsWith(raw_path, "/vsi") ||
-		    DuckDBFileSystemPrefix::IsGDALDriverPrefixedURL(raw_path)) {
+		if (StringUtil::StartsWith(raw_path, "/vsi") || DuckDBFileSystemPrefix::IsGDALDriverPrefixedURL(raw_path)) {
 			result->files.emplace_back(std::move(raw_path));
 		} else {
 			const auto mf_reader = MultiFileReader::Create(input.table_function);
@@ -2071,49 +2202,19 @@ void RegisterGDALModule(ExtensionLoader &loader) {
 		// Register all embedded drivers (dont go looking for plugins)
 		OGRRegisterAllInternal();
 
-		// Set GDAL error handler
+		// GDAL error handler. For ordinary failures we MUST NOT throw from here: GDAL is not exception-safe and an
+		// exception thrown from the handler unwinds through GDAL's own frames, leaking memory and potentially
+		// corrupting its state. Those are recorded in GDAL's thread-local state (CPLGetLastError*) and surfaced at our
+		// call boundaries via ThrowGDALError().
+		//
+		// CE_Fatal is the exception: GDAL would otherwise abort() the whole process right after the handler returns.
+		// Throwing here pre-empts that abort and lets DuckDB invalidate the database instead of hard-crashing. We
+		// accept the risk of unwinding through GDAL on a fatal error since the process was going to die regardless.
 		CPLSetErrorHandler([](CPLErr e, int code, const char *raw_msg) {
-			// DuckDB doesn't do warnings, so we only throw on errors
-			if (e != CE_Failure && e != CE_Fatal) {
-				return;
+			if (e == CE_Fatal) {
+				throw InternalException("Fatal GDAL error: " + CleanGDALMessage(raw_msg));
 			}
-
-			// GDAL Catches exceptions internally and passes them on to the handler again as CPLE_AppDefined
-			// So we don't add any extra information here or we end up with very long nested error messages.
-			// Using ErrorData we can parse the message part of DuckDB exceptions properly, and for other exceptions
-			// their error message will still be preserved as the "raw message".
-			ErrorData error_data(raw_msg);
-			auto msg = error_data.RawMessage();
-
-			// If the error contains a /vsiduckdb-<uuid>/ prefix,
-			// try to strip it off to make the errors more readable
-			auto path_pos = msg.find("/vsiduckdb-");
-			if (path_pos != string::npos) {
-				// We found a path, strip it off
-				msg.erase(path_pos, 48);
-			}
-
-			switch (code) {
-			case CPLE_NoWriteAccess:
-				throw PermissionException(msg);
-			case CPLE_UserInterrupt:
-				throw InterruptException();
-			case CPLE_OutOfMemory:
-				throw OutOfMemoryException(msg);
-			case CPLE_NotSupported:
-				throw NotImplementedException(msg);
-			case CPLE_AssertionFailed:
-			case CPLE_ObjectNull:
-				throw InternalException(msg);
-			case CPLE_IllegalArg:
-				throw InvalidInputException(msg);
-			case CPLE_AppDefined:
-			case CPLE_HttpResponse:
-			case CPLE_FileIO:
-			case CPLE_OpenFailed:
-			default:
-				throw IOException(msg);
-			}
+			// Otherwise a no-op: the error is captured in GDAL's thread-local state and surfaced at the boundary.
 		});
 	});
 
@@ -2121,6 +2222,5 @@ void RegisterGDALModule(ExtensionLoader &loader) {
 	gdal_copy::Register(loader);
 	gdal_list::Register(loader);
 	gdal_meta::Register(loader);
-
 }
 } // namespace duckdb

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -2071,12 +2071,6 @@ void RegisterGDALModule(ExtensionLoader &loader) {
 		// Register all embedded drivers (dont go looking for plugins)
 		OGRRegisterAllInternal();
 
-		std::atexit([]() {
-			// Cleanup GDAL on exit
-			OGRCleanupAll();
-			OSRCleanup();
-		});
-
 		// Set GDAL error handler
 		CPLSetErrorHandler([](CPLErr e, int code, const char *raw_msg) {
 			// DuckDB doesn't do warnings, so we only throw on errors

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -1483,7 +1483,7 @@ public:
 			dataset = nullptr;
 		}
 		if (srs) {
-			OSRDestroySpatialReference(srs);
+			OSRRelease(srs);
 			srs = nullptr;
 		}
 	}
@@ -2071,6 +2071,12 @@ void RegisterGDALModule(ExtensionLoader &loader) {
 		// Register all embedded drivers (dont go looking for plugins)
 		OGRRegisterAllInternal();
 
+		std::atexit([]() {
+			// Cleanup GDAL on exit
+			OGRCleanupAll();
+			OSRCleanup();
+		});
+
 		// Set GDAL error handler
 		CPLSetErrorHandler([](CPLErr e, int code, const char *raw_msg) {
 			// DuckDB doesn't do warnings, so we only throw on errors
@@ -2121,5 +2127,6 @@ void RegisterGDALModule(ExtensionLoader &loader) {
 	gdal_copy::Register(loader);
 	gdal_list::Register(loader);
 	gdal_meta::Register(loader);
+
 }
 } // namespace duckdb

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -1254,6 +1254,35 @@ public:
 	ArrowSchema schema;
 	unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_type_cast;
 
+	BindData() : geometry_type(wkbUnknown) {
+		schema.release = nullptr;
+	}
+
+	// Move constructor
+	BindData(BindData &&other) noexcept
+	    : driver_name(std::move(other.driver_name)), layer_name(std::move(other.layer_name)),
+	      driver_options(std::move(other.driver_options)), layer_options(std::move(other.layer_options)),
+	      target_srs(std::move(other.target_srs)), always_xy(other.always_xy),
+	      geometry_type(other.geometry_type), props(std::move(other.props)), schema(other.schema),
+	      extension_type_cast(std::move(other.extension_type_cast)) {
+		other.schema.release = nullptr;
+	}
+
+	// Move assignment operator
+	BindData &operator=(BindData &&other) noexcept {
+		std::swap(driver_name, other.driver_name);
+		std::swap(layer_name, other.layer_name);
+		std::swap(driver_options, other.driver_options);
+		std::swap(layer_options, other.layer_options);
+		std::swap(target_srs, other.target_srs);
+		std::swap(always_xy, other.always_xy);
+		std::swap(geometry_type, other.geometry_type);
+		std::swap(props, other.props);
+		std::swap(schema, other.schema);
+		std::swap(extension_type_cast, other.extension_type_cast);
+		return *this;
+	}
+
 	~BindData() override {
 		if (schema.release) {
 			schema.release(&schema);
@@ -1425,6 +1454,29 @@ auto Bind(ClientContext &context, CopyFunctionBindInput &input, const vector<Ide
 //----------------------------------------------------------------------------------------------------------------------
 class GlobalState final : public GlobalFunctionData {
 public:
+
+	GlobalState() {
+		dataset = nullptr;
+		layer = nullptr;
+		srs = nullptr;
+	}
+
+	// Move constructor
+	GlobalState(GlobalState &&other) noexcept
+	    : dataset(other.dataset), layer(other.layer), srs(other.srs) {
+		other.dataset = nullptr;
+		other.layer = nullptr;
+		other.srs = nullptr;
+	}
+
+	// Move assignment operator
+	GlobalState &operator=(GlobalState &&other) noexcept {
+		std::swap(dataset, other.dataset);
+		std::swap(layer, other.layer);
+		std::swap(srs, other.srs);
+		return *this;
+	}
+
 	~GlobalState() override {
 		if (dataset) {
 			GDALClose(dataset);
@@ -1437,9 +1489,9 @@ public:
 	}
 
 	mutex lock;
-	GDALDatasetH dataset = nullptr;
-	OGRLayerH layer = nullptr;
-	OGRSpatialReferenceH srs = nullptr;
+	GDALDatasetH dataset;
+	OGRLayerH layer;
+	OGRSpatialReferenceH srs;
 };
 
 auto InitGlobal(ClientContext &context, FunctionData &bdata_p, const string &real_file_path)
@@ -1537,6 +1589,22 @@ auto InitGlobal(ClientContext &context, FunctionData &bdata_p, const string &rea
 //----------------------------------------------------------------------------------------------------------------------
 class LocalState final : public LocalFunctionData {
 public:
+
+	LocalState() {
+		array.release = nullptr;
+	}
+
+	// Move constructor
+	LocalState(LocalState &&other) noexcept : array(other.array) {
+		other.array.release = nullptr;
+	}
+
+	// Move assignment operator
+	LocalState &operator=(LocalState &&other) noexcept {
+		std::swap(array, other.array);
+		return *this;
+	}
+
 	~LocalState() override {
 		if (array.release) {
 			array.release(&array);

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -2663,6 +2663,16 @@ struct ST_Union_Agg {
 	struct State {
 		GEOSContextHandle_t context = nullptr;
 		vector<GEOSGeometry *> geoms;
+
+		~State() {
+			if (context) {
+				for (auto geom : geoms) {
+					GEOSGeom_destroy_r(context, geom);
+				}
+				GEOS_finish_r(context);
+				context = nullptr;
+			}
+		}
 	};
 
 	static idx_t StateSize(const BoundAggregateFunction &) {
@@ -2823,14 +2833,8 @@ struct ST_Union_Agg {
 		for (idx_t raw_idx = 0; raw_idx < count; raw_idx++) {
 			const auto row_idx = state_format.sel->get_index(raw_idx);
 			if (state_format.validity.RowIsValid(row_idx)) {
-				auto &state = *state_ptr[row_idx];
-
-				state.geoms.clear();
-
-				if (state.context) {
-					GEOS_finish_r(state.context);
-					state.context = nullptr;
-				}
+				// Destroy the state object
+				state_ptr[row_idx]->~State();
 			}
 		}
 	}
@@ -2867,6 +2871,16 @@ struct GEOSCoverageAggFunction {
 		double tolerance = 0;
 		bool parameters_set = false;
 		bool simplify_boundary = false;
+
+		~State() {
+			if (context) {
+				for (auto geom : geoms) {
+					GEOSGeom_destroy_r(context, geom);
+				}
+				GEOS_finish_r(context);
+				context = nullptr;
+			}
+		}
 	};
 
 	// Serialize a GEOS geometry
@@ -3010,14 +3024,7 @@ struct GEOSCoverageAggFunction {
 		for (idx_t raw_idx = 0; raw_idx < count; raw_idx++) {
 			const auto row_idx = state_format.sel->get_index(raw_idx);
 			if (state_format.validity.RowIsValid(row_idx)) {
-				auto &state = *state_ptr[row_idx];
-
-				state.geoms.clear();
-
-				if (state.context) {
-					GEOS_finish_r(state.context);
-					state.context = nullptr;
-				}
+				state_ptr[row_idx]->~State();
 			}
 		}
 	}

--- a/src/spatial/modules/geos/geos_serde.cpp
+++ b/src/spatial/modules/geos/geos_serde.cpp
@@ -209,7 +209,7 @@ void GeosSerde::Serialize(GEOSContextHandle_t ctx, const GEOSGeom_t *geom, char 
 static GEOSGeom_t *DeserializeInternal(BinaryReader &reader, ArenaAllocator &arena, GEOSContextHandle_t ctx);
 
 template <class T>
-static T *AllocateArray(ArenaAllocator &arena, size_t count) {
+static T *MakeArray(ArenaAllocator &arena, size_t count) {
 	return reinterpret_cast<T *>(arena.AllocateAligned(count * sizeof(T)));
 }
 
@@ -232,7 +232,7 @@ static GEOSGeom_t *DeserializeTemplated(BinaryReader &reader, ArenaAllocator &ar
 		if (vert_count == 0) {
 			return GEOSGeom_createEmptyLineString_r(ctx);
 		}
-		auto vert_array = AllocateArray<double>(arena, vert_count * VERTEX_SIZE);
+		auto vert_array = MakeArray<double>(arena, vert_count * VERTEX_SIZE);
 		auto ptr = reader.Reserve(vert_count * VERTEX_SIZE * sizeof(double));
 		memcpy(vert_array, ptr, vert_count * VERTEX_SIZE * sizeof(double));
 		auto seq = GEOSCoordSeq_copyFromBuffer_r(ctx, vert_array, vert_count, V::HAS_Z, V::HAS_M);
@@ -243,10 +243,10 @@ static GEOSGeom_t *DeserializeTemplated(BinaryReader &reader, ArenaAllocator &ar
 		if (ring_count == 0) {
 			return GEOSGeom_createEmptyPolygon_r(ctx);
 		}
-		auto ring_array = AllocateArray<GEOSGeometry *>(ring_count);
+		auto ring_array = MakeArray<GEOSGeometry *>(arena, ring_count);
 		for (uint32_t i = 0; i < ring_count; i++) {
 			const auto vert_count = reader.Read<uint32_t>();
-			auto vert_array = AllocateArray<double>(arena, vert_count * VERTEX_SIZE);
+			auto vert_array = MakeArray<double>(arena, vert_count * VERTEX_SIZE);
 			auto ptr = reader.Reserve(vert_count * VERTEX_SIZE * sizeof(double));
 			memcpy(vert_array, ptr, vert_count * VERTEX_SIZE * sizeof(double));
 			auto seq = GEOSCoordSeq_copyFromBuffer_r(ctx, vert_array, vert_count, V::HAS_Z, V::HAS_M);
@@ -259,7 +259,7 @@ static GEOSGeom_t *DeserializeTemplated(BinaryReader &reader, ArenaAllocator &ar
 		if (part_count == 0) {
 			return GEOSGeom_createEmptyCollection_r(ctx, GEOS_MULTIPOINT);
 		}
-		const auto part_array = AllocateArray<GEOSGeometry *>(arena, part_count);
+		const auto part_array = MakeArray<GEOSGeometry *>(arena, part_count);
 		for (uint32_t i = 0; i < part_count; i++) {
 			part_array[i] = DeserializeInternal(reader, arena, ctx);
 		}
@@ -270,7 +270,7 @@ static GEOSGeom_t *DeserializeTemplated(BinaryReader &reader, ArenaAllocator &ar
 		if (part_count == 0) {
 			return GEOSGeom_createEmptyCollection_r(ctx, GEOS_MULTILINESTRING);
 		}
-		const auto part_array = AllocateArray<GEOSGeometry *>(arena, part_count);
+		const auto part_array = MakeArray<GEOSGeometry *>(arena, part_count);
 		for (uint32_t i = 0; i < part_count; i++) {
 			part_array[i] = DeserializeInternal(reader, arena, ctx);
 		}
@@ -281,7 +281,7 @@ static GEOSGeom_t *DeserializeTemplated(BinaryReader &reader, ArenaAllocator &ar
 		if (part_count == 0) {
 			return GEOSGeom_createEmptyCollection_r(ctx, GEOS_MULTIPOLYGON);
 		}
-		const auto part_array = AllocateArray<GEOSGeometry *>(arena, part_count);
+		const auto part_array = MakeArray<GEOSGeometry *>(arena, part_count);
 		for (uint32_t i = 0; i < part_count; i++) {
 			part_array[i] = DeserializeInternal(reader, arena, ctx);
 		}
@@ -292,7 +292,7 @@ static GEOSGeom_t *DeserializeTemplated(BinaryReader &reader, ArenaAllocator &ar
 		if (part_count == 0) {
 			return GEOSGeom_createEmptyCollection_r(ctx, GEOS_GEOMETRYCOLLECTION);
 		}
-		const auto part_array = AllocateArray<GEOSGeometry *>(arena, part_count);
+		const auto part_array = MakeArray<GEOSGeometry *>(arena, part_count);
 		for (uint32_t i = 0; i < part_count; i++) {
 			part_array[i] = DeserializeInternal(reader, arena, ctx);
 		}

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -92,6 +92,11 @@ void ProjModule::RegisterVFS(ExtensionLoader &loader) {
 		// this way we don't have to worry about the user having the proj.db database installed
 		// on their system. We therefore have to tell proj to use memvfs as the sqlite3 vfs and
 		// point it to the segment of the binary that contains the proj.db database
+		std::atexit([]() {
+			// Cleanup sqlite3 on exit
+			sqlite3_shutdown();
+			proj_cleanup();
+		});
 
 		sqlite3_initialize();
 		sqlite3_memvfs_init(nullptr, nullptr, nullptr);

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -113,13 +113,17 @@ void ProjModule::RegisterVFS(ExtensionLoader &loader) {
 		sqlite3 *sdb = nullptr;
 		const auto sok = sqlite3_open_v2(path.c_str(), &sdb, SQLITE_OPEN_READONLY, "memvfs");
 		if (sok != SQLITE_OK) {
+			sqlite3_close_v2(sdb);
 			throw InternalException("Could not open sqlite3 memvfs database");
 		}
 
 		const auto ok = proj_context_set_database_path(nullptr, path.c_str(), nullptr, nullptr);
 		if (!ok) {
+			sqlite3_close_v2(sdb);
 			throw InternalException("Could not set proj.db path");
 		}
+
+		sqlite3_close_v2(sdb);
 	});
 }
 

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -92,11 +92,6 @@ void ProjModule::RegisterVFS(ExtensionLoader &loader) {
 		// this way we don't have to worry about the user having the proj.db database installed
 		// on their system. We therefore have to tell proj to use memvfs as the sqlite3 vfs and
 		// point it to the segment of the binary that contains the proj.db database
-		std::atexit([]() {
-			// Cleanup sqlite3 on exit
-			sqlite3_shutdown();
-			proj_cleanup();
-		});
 
 		sqlite3_initialize();
 		sqlite3_memvfs_init(nullptr, nullptr, nullptr);

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -1709,6 +1709,7 @@ bool IdentifyProjCRS(const char *crs, string &auth_name, string &auth_code) {
 	auto n_candidates = proj_list_get_count(candidates);
 	if (n_candidates == 0) {
 		proj_list_destroy(candidates);
+		proj_int_list_destroy(confidence);
 		proj_destroy(pj);
 		proj_context_destroy(ctx);
 		return false;
@@ -1718,6 +1719,7 @@ bool IdentifyProjCRS(const char *crs, string &auth_name, string &auth_code) {
 	auto candidate = proj_list_get(ctx, candidates, 0);
 	if (!candidate) {
 		proj_list_destroy(candidates);
+		proj_int_list_destroy(confidence);
 		proj_destroy(pj);
 		proj_context_destroy(ctx);
 		return false;
@@ -1726,7 +1728,9 @@ bool IdentifyProjCRS(const char *crs, string &auth_name, string &auth_code) {
 	if (confidence[0] < 70) {
 		// The confidence is too low, so we consider it a failed identification
 		proj_list_destroy(candidates);
+		proj_int_list_destroy(confidence);
 		proj_destroy(pj);
+		proj_destroy(candidate);
 		proj_context_destroy(ctx);
 		return false;
 	}
@@ -1736,7 +1740,9 @@ bool IdentifyProjCRS(const char *crs, string &auth_name, string &auth_code) {
 
 	if (!proj_auth_name || !proj_auth_code) {
 		proj_list_destroy(candidates);
+		proj_int_list_destroy(confidence);
 		proj_destroy(pj);
+		proj_destroy(candidate);
 		proj_context_destroy(ctx);
 		return false;
 	}
@@ -1745,7 +1751,9 @@ bool IdentifyProjCRS(const char *crs, string &auth_name, string &auth_code) {
 	auth_code = proj_auth_code;
 
 	proj_list_destroy(candidates);
+	proj_int_list_destroy(confidence);
 	proj_destroy(pj);
+	proj_destroy(candidate);
 	proj_context_destroy(ctx);
 
 	return true;

--- a/src/spatial/operators/spatial_join_optimizer.cpp
+++ b/src/spatial/operators/spatial_join_optimizer.cpp
@@ -69,9 +69,10 @@ static unique_ptr<Expression> GetInversePredicate(ClientContext &context, unique
 
 	// Get the function from the catalog
 	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), Identifier(it->second));
-	const auto &inverse_func =
-	    entry.functions.GetFunctionByArguments(context, {func.GetChildren()[0]->GetReturnType(), func.GetChildren()[1]->GetReturnType()});
+	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), Identifier(it->second)));
+	const auto &inverse_func = entry.functions.GetFunctionByArguments(
+	    context, {func.GetChildren()[0]->GetReturnType(), func.GetChildren()[1]->GetReturnType()});
 
 	auto func_expr = inverse_func.Bind(context, std::move(func.GetChildrenMutable()));
 	return std::move(func_expr);

--- a/src/spatial/operators/spatial_join_physical.cpp
+++ b/src/spatial/operators/spatial_join_physical.cpp
@@ -386,7 +386,8 @@ private:
 
 static unique_ptr<Expression> GetBBOXExpression(ClientContext &context, const LogicalType &geom_type) {
 	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "ST_Extent_Approx");
+	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "ST_Extent_Approx"));
 	const auto &func = entry.functions.GetFunctionByArguments(context, {geom_type});
 
 	auto child_expr = make_uniq<BoundReferenceExpression>(geom_type, 0);
@@ -546,8 +547,8 @@ public:
 		auto &geom_type = op.build_side_key->GetReturnType();
 
 		auto &catalog = Catalog::GetSystemCatalog(context);
-		auto &entry =
-	    catalog.GetEntry<ScalarFunctionCatalogEntry>(context, Identifier::DefaultSchema(), "ST_IsEmpty");
+		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
+		    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "ST_IsEmpty"));
 		const auto &func = entry.functions.GetFunctionByArguments(context, {geom_type});
 
 		vector<unique_ptr<Expression>> children;
@@ -560,7 +561,8 @@ public:
 
 		auto is_not_null_expr =
 		    make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, LogicalTypeId::BOOLEAN);
-		is_not_null_expr->GetChildrenMutable().push_back(make_uniq_base<Expression, BoundReferenceExpression>(geom_type, 0));
+		is_not_null_expr->GetChildrenMutable().push_back(
+		    make_uniq_base<Expression, BoundReferenceExpression>(geom_type, 0));
 
 		auto filter_expr = make_uniq_base<Expression, BoundConjunctionExpression>(
 		    ExpressionType::CONJUNCTION_AND, std::move(is_not_empty_expr), std::move(is_not_null_expr));
@@ -857,7 +859,8 @@ unique_ptr<OperatorState> PhysicalSpatialJoin::GetOperatorState(ExecutionContext
 	lstate->probe_side_key_chunk.Initialize(context.client, {probe_side_key->GetReturnType()});
 	lstate->probe_side_box_chunk.Initialize(context.client, {lstate->bound_expr->GetReturnType()});
 	lstate->build_side_key_chunk.Initialize(context.client, {build_side_key->GetReturnType()});
-	lstate->match_pred_arg_chunk.Initialize(context.client, {probe_side_key->GetReturnType(), build_side_key->GetReturnType()});
+	lstate->match_pred_arg_chunk.Initialize(context.client,
+	                                        {probe_side_key->GetReturnType(), build_side_key->GetReturnType()});
 
 	return std::move(lstate);
 }

--- a/src/spatial/util/binary_writer.hpp
+++ b/src/spatial/util/binary_writer.hpp
@@ -39,6 +39,14 @@ public:
 	}
 
 	void Copy(const char *buffer, const size_t size) {
+		if (buffer == nullptr) {
+			D_ASSERT(size == 0);
+			return;
+		}
+		if (size == 0) {
+			return;
+		}
+
 		CheckSize(size);
 		memcpy(ptr, buffer, size);
 		ptr += size;

--- a/test/sql/gdal/gdal_axis_order.test
+++ b/test/sql/gdal/gdal_axis_order.test
@@ -4,13 +4,17 @@ statement ok
 CREATE TABLE data (id int, geom geometry);
 
 statement ok
-INSERT INTO data VALUES (1, ST_MakePoint(100.446569, 0));
+INSERT INTO data VALUES (1, ST_MakePoint(100, 0));
 
-# Should error, KML validates coordinate ranges
-statement error
+# The KML driver does not validate coordinate ranges reliably, so dont expect an error here.
+# - (only once per process, and also just sets an error, not a warning, but still returns success)
+statement ok
 COPY data TO '{TEST_DIR}/output.kml' WITH (FORMAT GDAL, DRIVER 'KML', SRS 'EPSG:4326');
+
+query I
+select geom from st_read('{TEST_DIR}/output.kml');
 ----
-IO Error: Latitude 100.446569 is invalid. Valid range is [-90,90]. This warning will not be issued any more
+POINT (0 100)
 
 # Tell DuckDB to ignore CRS authority and always consider coordinates in XY order
 statement ok
@@ -19,3 +23,8 @@ SET geometry_always_xy = true;
 # Now works
 statement ok
 COPY data TO '{TEST_DIR}/output.kml' WITH (FORMAT GDAL, DRIVER 'KML', SRS 'EPSG:4326');
+
+query I
+select geom from st_read('{TEST_DIR}/output.kml');
+----
+POINT (100 0)

--- a/test/sql/index/rtree_basic.test
+++ b/test/sql/index/rtree_basic.test
@@ -1,6 +1,9 @@
 require spatial
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 CREATE TABLE t1 (geom GEOMETRY);
 
 statement ok

--- a/test/sql/index/rtree_basic_data.test_slow
+++ b/test/sql/index/rtree_basic_data.test_slow
@@ -3,6 +3,9 @@ require parquet
 require spatial
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 CREATE TABLE t1 as SELECT st_point(pickup_longitude, pickup_latitude) as geom, trip_distance, fare_amount
 FROM read_parquet('{WORKING_DIRECTORY}/test/data/nyc_taxi/yellow_tripdata_2010-01-limit1mil.parquet');
 

--- a/test/sql/index/rtree_basic_points.test
+++ b/test/sql/index/rtree_basic_points.test
@@ -1,6 +1,9 @@
 require spatial
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 CREATE TABLE t1 AS SELECT point::GEOMETRY as geom
 FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 1000, max_y: 1000}::BOX_2D, 100_00, 1337);
 

--- a/test/sql/index/rtree_multi.test
+++ b/test/sql/index/rtree_multi.test
@@ -4,6 +4,9 @@
 require spatial
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 CREATE TABLE t1 (id INT, g1 GEOMETRY, g2 GEOMETRY);
 
 statement ok

--- a/test/sql/index/rtree_multiple_index.test
+++ b/test/sql/index/rtree_multiple_index.test
@@ -2,6 +2,9 @@ require spatial
 
 # Create a table with 10_000 random points, where the table also has an ART primary key index
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 CREATE TABLE IF NOT EXISTS t1 (
             id          LONG PRIMARY KEY,
             geom        GEOMETRY

--- a/test/sql/index/rtree_persistence.test_slow
+++ b/test/sql/index/rtree_persistence.test_slow
@@ -4,6 +4,9 @@ require spatial
 load {TEST_DIR}/rtree_persistence_test.db
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 CREATE TABLE t1 AS SELECT point::GEOMETRY as geom
 FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 10000, max_y: 10000}::BOX_2D, 1_000_000, 1337);
 
@@ -21,6 +24,9 @@ EXPLAIN SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(450, 450, 
 physical_plan	<REGEX>:.*RTREE_INDEX_SCAN.*
 
 restart
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
 
 # We should still have the index
 query II

--- a/test/sql/index/rtree_persistence_load.test
+++ b/test/sql/index/rtree_persistence_load.test
@@ -4,6 +4,9 @@ require spatial
 load {TEST_DIR}/rtree_persistence_test.db
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 CREATE TABLE t1 AS SELECT point::GEOMETRY as geom
 FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 10000, max_y: 10000}::BOX_2D, 100_000, 1337);
 
@@ -22,6 +25,9 @@ physical_plan	<REGEX>:.*RTREE_INDEX_SCAN.*
 
 restart no_extension_load
 
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
 # Try to modify the table
 statement error
 DELETE FROM t1 WHERE rowid < 1000;
@@ -29,6 +35,9 @@ DELETE FROM t1 WHERE rowid < 1000;
 Missing Extension Error: Cannot bind index 't1', unknown index type 'RTREE'. You need to load the extension that provides this index type before table 't1' can be modified.
 
 restart
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
 
 # We should still have the index
 query II

--- a/test/sql/index/rtree_persistence_wal.test
+++ b/test/sql/index/rtree_persistence_wal.test
@@ -4,6 +4,9 @@ require spatial
 load {TEST_DIR}/rtree_persistence_wal_test.db
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 PRAGMA disable_checkpoint_on_shutdown;
 
 statement ok
@@ -24,6 +27,9 @@ EXPLAIN SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(450, 450, 
 physical_plan	<REGEX>:.*RTREE_INDEX_SCAN.*
 
 restart
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
 
 # We should still have the index
 query II

--- a/test/sql/index/rtree_pushdown.test
+++ b/test/sql/index/rtree_pushdown.test
@@ -1,6 +1,9 @@
 require spatial
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 CREATE TABLE t1 (geom GEOMETRY, id INT);
 
 statement ok

--- a/test/sql/join/spatial_join_extra_pred.test
+++ b/test/sql/join/spatial_join_extra_pred.test
@@ -1,6 +1,9 @@
 require spatial
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 CREATE TABLE t1 AS
 SELECT
     ST_Buffer(ST_Point(x, y), 5) as geom,

--- a/test/sql/join/spatial_join_outer.test_slow
+++ b/test/sql/join/spatial_join_outer.test_slow
@@ -3,6 +3,9 @@ require spatial
 # Create a bunch of points on a grid
 # between 0 and 500 in both x and y directions
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 CREATE TABLE lhs AS
 SELECT
     ST_Point(x, y) as geom,

--- a/test/sql/join/spatial_join_predicates.test
+++ b/test/sql/join/spatial_join_predicates.test
@@ -2,6 +2,9 @@ require spatial
 
 # Set up test tables
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 CREATE TABLE lhs AS
 SELECT
     ST_Point(x, y) as geom,

--- a/test/sql/join/spatial_join_test.test_slow
+++ b/test/sql/join/spatial_join_test.test_slow
@@ -1,6 +1,9 @@
 require spatial
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 create table t1(g GEOMETRY);
 
 # Create a bunch of points on a grid

--- a/test/sql/join/spatial_join_test_2.test_slow
+++ b/test/sql/join/spatial_join_test_2.test_slow
@@ -1,6 +1,9 @@
 require spatial
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 SELECT setseed(0.5);
 
 statement ok

--- a/test/sql/join/spatial_join_test_3.test_slow
+++ b/test/sql/join/spatial_join_test_3.test_slow
@@ -1,6 +1,9 @@
 require spatial
 
 statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
 SELECT setseed(0.5);
 
 statement ok


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9787

I want to repeatedly run extensions tests to detect (more) ASAN failures in CI. Some tests can fail "randomly" (if the right code paths are executed) and that affects duckdb CI on main and in PRs (and some customers that build duckdb from main).

The extension author is not always aware of failure when bumping the extension in duckdb, and re-running tests should reduce the chance of merging code that fails once every ~ten runs.

I'm trying the new CLI flag `--stabilize-tests` in this extension first to see what we discover. It could be that we move the changes elsewhere (like `extension-ci-tools`) in the future.