### PR TITLE
Support geometry with CRS in R-Tree columns, Improve R-Tree scans

### DIFF
--- a/src/spatial/index/rtree/rtree_index_create_logical.cpp
+++ b/src/spatial/index/rtree/rtree_index_create_logical.cpp
@@ -72,16 +72,17 @@ static PhysicalOperator &CreateNullFilter(PhysicalPlanGenerator &generator, cons
 }
 
 static PhysicalOperator &CreateBoundingBoxProjection(PhysicalPlanGenerator &planner, const LogicalOperator &op,
-                                                     const vector<LogicalType> &types, ClientContext &context) {
+                                                     const vector<LogicalType> &types, const LogicalType &geom_type,
+                                                     ClientContext &context) {
 	auto &catalog = Catalog::GetSystemCatalog(context);
 
 	// Get the bounding box function
 	auto &bbox_func_entry =
 	    catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, DEFAULT_SCHEMA, "ST_Extent_Approx")
 	        .Cast<ScalarFunctionCatalogEntry>();
-	auto bbox_func = bbox_func_entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
+	auto bbox_func = bbox_func_entry.functions.GetFunctionByArguments(context, {geom_type});
 
-	auto geom_ref_expr = make_uniq_base<Expression, BoundReferenceExpression>(LogicalType::GEOMETRY(), 0);
+	auto geom_ref_expr = make_uniq_base<Expression, BoundReferenceExpression>(geom_type, 0);
 	vector<unique_ptr<Expression>> bbox_args;
 	bbox_args.push_back(std::move(geom_ref_expr));
 
@@ -150,8 +151,8 @@ PhysicalOperator &RTreeIndex::CreatePlan(PlanIndexInput &input) {
 
 	auto &expr = op.unbound_expressions[0];
 
-	// Validate that we have the right type of expression (float array)
-	if (expr->return_type != LogicalType::GEOMETRY()) {
+	// Validate that we have the right type of expression (also allow GEOMETRY types with a CRS)
+	if (expr->return_type.id() != LogicalTypeId::GEOMETRY) {
 		throw BinderException("RTree indexes can only be created over GEOMETRY columns.");
 	}
 
@@ -185,7 +186,7 @@ PhysicalOperator &RTreeIndex::CreatePlan(PlanIndexInput &input) {
 
 	// Project the bounding box and the row ID
 	vector<LogicalType> projected_types = {GeoTypes::BOX_2DF(), LogicalType::ROW_TYPE};
-	auto &bbox_proj = CreateBoundingBoxProjection(planner, op, projected_types, context);
+	auto &bbox_proj = CreateBoundingBoxProjection(planner, op, projected_types, new_column_types[0], context);
 	bbox_proj.children.push_back(null_filter);
 
 	// Create an ORDER_BY operator to sort the bounding boxes by the xmin value
@@ -217,8 +218,8 @@ PhysicalOperator &LogicalCreateRTreeIndex::CreatePlan(ClientContext &context, Ph
 
 	auto &expr = op.unbound_expressions[0];
 
-	// Validate that we have the right type of expression (float array)
-	if (expr->return_type != LogicalType::GEOMETRY()) {
+	// Validate that we have the right type of expression (also allow GEOMETRY types with a CRS)
+	if (expr->return_type.id() != LogicalTypeId::GEOMETRY) {
 		throw BinderException("RTree indexes can only be created over GEOMETRY columns.");
 	}
 
@@ -262,7 +263,7 @@ PhysicalOperator &LogicalCreateRTreeIndex::CreatePlan(ClientContext &context, Ph
 
 	// Project the bounding box and the row ID
 	vector<LogicalType> projected_types = {GeoTypes::BOX_2DF(), LogicalType::ROW_TYPE};
-	auto &bbox_proj = CreateBoundingBoxProjection(planner, op, projected_types, context);
+	auto &bbox_proj = CreateBoundingBoxProjection(planner, op, projected_types, new_column_types[0], context);
 	bbox_proj.children.push_back(null_filter);
 
 	// Create an ORDER_BY operator to sort the bounding boxes by the xmin value

--- a/src/spatial/index/rtree/rtree_index_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_scan.cpp
@@ -169,6 +169,21 @@ unique_ptr<NodeStatistics> RTreeIndexScanCardinality(ClientContext &context, con
 }
 
 //-------------------------------------------------------------------------
+// Virtual Columns
+//-------------------------------------------------------------------------
+static virtual_column_map_t RTreeIndexScanGetVirtualColumns(ClientContext &context,
+                                                            optional_ptr<FunctionData> bind_data_p) {
+	auto &bind_data = bind_data_p->Cast<RTreeIndexScanBindData>();
+	return bind_data.table.GetVirtualColumns();
+}
+
+static vector<column_t> RTreeIndexScanGetRowIdColumns(ClientContext &context, optional_ptr<FunctionData> bind_data) {
+	vector<column_t> result;
+	result.emplace_back(COLUMN_IDENTIFIER_ROW_ID);
+	return result;
+}
+
+//-------------------------------------------------------------------------
 // ToString
 //-------------------------------------------------------------------------
 static InsertionOrderPreservingMap<string> RTreeIndexScanToString(TableFunctionToStringInput &input) {
@@ -261,6 +276,8 @@ TableFunction RTreeIndexScanFunction::GetFunction() {
 	func.get_bind_info = RTreeIndexScanBindInfo;
 	func.serialize = RTreeScanSerialize;
 	func.deserialize = RTreeScanDeserialize;
+	func.get_virtual_columns = RTreeIndexScanGetVirtualColumns;
+	func.get_row_id_columns = RTreeIndexScanGetRowIdColumns;
 
 	return func;
 }

--- a/src/spatial/index/rtree/rtree_index_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_scan.cpp
@@ -27,18 +27,30 @@ BindInfo RTreeIndexScanBindInfo(const optional_ptr<FunctionData> bind_data_p) {
 // Global State
 //-------------------------------------------------------------------------
 struct RTreeIndexScanGlobalState final : public GlobalTableFunctionState {
-	//! The DataChunk containing all read columns.
-	//! This includes filter columns, which are immediately removed.
-	DataChunk all_columns;
+	//! The maximum number of threads for this scan
+	idx_t max_threads = 1;
+
+	//! The storage column ids to fetch
+	vector<StorageIndex> column_ids;
+	//! The types of all scanned columns, including filter columns that are removed afterwards
+	vector<LogicalType> scanned_types;
 	vector<idx_t> projection_ids;
 
-	ColumnFetchState fetch_state;
-	TableScanState local_storage_state;
-	vector<StorageIndex> column_ids;
-
-	// Index scan state
+	//! Lock protecting the shared state below
+	mutex lock;
+	//! The index scan state, shared by all threads
 	unique_ptr<IndexScanState> index_state;
-	Vector row_ids = Vector(LogicalType::ROW_TYPE);
+	//! Whether the index scan is exhausted
+	bool index_exhausted = false;
+	//! Whether a thread has been assigned to scan the transaction-local storage
+	bool local_storage_scan_assigned = false;
+
+	idx_t MaxThreads() const override {
+		return max_threads;
+	}
+	bool CanRemoveFilterColumns() const {
+		return !projection_ids.empty();
+	}
 };
 
 static unique_ptr<GlobalTableFunctionState> RTreeIndexScanInitGlobal(ClientContext &context,
@@ -46,11 +58,11 @@ static unique_ptr<GlobalTableFunctionState> RTreeIndexScanInitGlobal(ClientConte
 	auto &bind_data = input.bind_data->Cast<RTreeIndexScanBindData>();
 	auto result = make_uniq<RTreeIndexScanGlobalState>();
 
-	// Setup the scan state for the local storage
-	auto &local_storage = LocalStorage::Get(context, bind_data.table.catalog);
-	result->column_ids.reserve(input.column_ids.size());
+	// While the index itself is scanned by one thread at a time, fetching the rows can happen in parallel
+	result->max_threads = bind_data.table.GetStorage().MaxThreads(context);
 
 	// Figure out the storage column ids
+	result->column_ids.reserve(input.column_ids.size());
 	for (auto &id : input.column_ids) {
 		storage_t col_id = id;
 		if (id != DConstants::INVALID_INDEX) {
@@ -58,10 +70,6 @@ static unique_ptr<GlobalTableFunctionState> RTreeIndexScanInitGlobal(ClientConte
 		}
 		result->column_ids.emplace_back(col_id);
 	}
-
-	// Initialize the storage scan state
-	result->local_storage_state.Initialize(result->column_ids, context, input.filters);
-	local_storage.InitializeScan(bind_data.table.GetStorage(), result->local_storage_state.local_state, input.filters);
 
 	// Initialize the scan state for the index
 	result->index_state = bind_data.index.Cast<RTreeIndex>().InitializeScan(bind_data.bbox);
@@ -76,16 +84,51 @@ static unique_ptr<GlobalTableFunctionState> RTreeIndexScanInitGlobal(ClientConte
 
 	auto &duck_table = bind_data.table.Cast<DuckTableEntry>();
 	const auto &columns = duck_table.GetColumns();
-	vector<LogicalType> scanned_types;
 	for (const auto &col_idx : input.column_indexes) {
 		if (col_idx.IsRowIdColumn()) {
-			scanned_types.emplace_back(LogicalType::ROW_TYPE);
+			result->scanned_types.emplace_back(LogicalType::ROW_TYPE);
 		} else {
-			scanned_types.push_back(columns.GetColumn(col_idx.ToLogical()).Type());
+			result->scanned_types.push_back(columns.GetColumn(col_idx.ToLogical()).Type());
 		}
 	}
-	result->all_columns.Initialize(context, scanned_types);
 
+	return std::move(result);
+}
+
+//-------------------------------------------------------------------------
+// Local State
+//-------------------------------------------------------------------------
+struct RTreeIndexScanLocalState final : public LocalTableFunctionState {
+	//! The row ids scanned from the index by this thread
+	Vector row_ids = Vector(LogicalType::ROW_TYPE);
+	//! The fetch state used to fetch rows from the main storage
+	ColumnFetchState fetch_state;
+	//! Scan state for the transaction-local storage
+	TableScanState local_storage_state;
+	vector<StorageIndex> column_ids;
+	//! The DataChunk containing all read columns.
+	//! This includes filter columns, which are immediately removed.
+	DataChunk all_columns;
+	//! Whether this thread is in charge of scanning the transaction-local storage
+	bool in_charge_of_local_storage = false;
+};
+
+static unique_ptr<LocalTableFunctionState> RTreeIndexScanInitLocal(ExecutionContext &context,
+                                                                   TableFunctionInitInput &input,
+                                                                   GlobalTableFunctionState *global_state) {
+	auto &bind_data = input.bind_data->Cast<RTreeIndexScanBindData>();
+	auto &g_state = global_state->Cast<RTreeIndexScanGlobalState>();
+	auto result = make_uniq<RTreeIndexScanLocalState>();
+
+	// Setup the scan state for the local storage
+	auto &local_storage = LocalStorage::Get(context.client, bind_data.table.catalog);
+	result->column_ids = g_state.column_ids;
+	result->local_storage_state.Initialize(result->column_ids, context.client, input.filters);
+	local_storage.InitializeScan(bind_data.table.GetStorage(), result->local_storage_state.local_state, input.filters);
+
+	if (g_state.CanRemoveFilterColumns()) {
+		result->all_columns.Initialize(context.client, g_state.scanned_types);
+	}
 	return std::move(result);
 }
 
@@ -95,41 +138,85 @@ static unique_ptr<GlobalTableFunctionState> RTreeIndexScanInitGlobal(ClientConte
 static void RTreeIndexScanExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 
 	auto &bind_data = data_p.bind_data->Cast<RTreeIndexScanBindData>();
-	auto &state = data_p.global_state->Cast<RTreeIndexScanGlobalState>();
+	auto &g_state = data_p.global_state->Cast<RTreeIndexScanGlobalState>();
+	auto &l_state = data_p.local_state->Cast<RTreeIndexScanLocalState>();
 	auto &transaction = DuckTransaction::Get(context, bind_data.table.catalog);
+	auto &index = bind_data.index.Cast<RTreeIndex>();
 
-	// Scan the index for row id's
-	auto row_count = bind_data.index.Cast<RTreeIndex>().Scan(*state.index_state, state.row_ids);
+	enum class ExecutionPhase { NONE, STORAGE, LOCAL_STORAGE };
 
-	if (row_count == 0) {
-		// Index is exhausted, fetch from local storage instead.
-		// This won't be indexed, but at least we get the correct results.
-		auto &local_storage = LocalStorage::Get(transaction);
-
-		// If there are no projection ids, we can directly scan into the output
-		if (state.projection_ids.empty()) {
-			local_storage.Scan(state.local_storage_state.local_state, state.column_ids, output);
-			return;
+	// We might need to loop back if a fetched batch turns out to be empty
+	while (true) {
+		idx_t row_count = 0;
+		auto phase = ExecutionPhase::NONE;
+		{
+			// Scan the index for the next batch of row ids while holding the lock
+			lock_guard<mutex> guard(g_state.lock);
+			if (!g_state.index_exhausted) {
+				row_count = index.Scan(*g_state.index_state, l_state.row_ids);
+				if (row_count != 0) {
+					phase = ExecutionPhase::STORAGE;
+				} else {
+					g_state.index_exhausted = true;
+				}
+			}
+			if (phase == ExecutionPhase::NONE) {
+				// The index is exhausted: the first thread to get here is assigned to scan whatever is in the
+				// transaction-local storage, all other threads are done.
+				if (!g_state.local_storage_scan_assigned) {
+					g_state.local_storage_scan_assigned = true;
+					l_state.in_charge_of_local_storage = true;
+				}
+				if (l_state.in_charge_of_local_storage) {
+					phase = ExecutionPhase::LOCAL_STORAGE;
+				}
+			}
 		}
 
-		// Otherwise we need to scan into our scan chunk, and then project out the result
-		state.all_columns.Reset();
-		local_storage.Scan(state.local_storage_state.local_state, state.column_ids, state.all_columns);
-		output.ReferenceColumns(state.all_columns, state.projection_ids);
+		switch (phase) {
+		case ExecutionPhase::NONE: {
+			// No more work to pick up
+			return;
+		}
+		case ExecutionPhase::STORAGE: {
+			// Fetch the data from the main storage given the row ids, in parallel, without holding the lock
+			if (!g_state.CanRemoveFilterColumns()) {
+				bind_data.table.GetStorage().Fetch(transaction, output, g_state.column_ids, l_state.row_ids, row_count,
+				                                   l_state.fetch_state);
+			} else {
+				// We need to first fetch into our scan chunk, and then project out the result
+				l_state.all_columns.Reset();
+				bind_data.table.GetStorage().Fetch(transaction, l_state.all_columns, g_state.column_ids,
+				                                   l_state.row_ids, row_count, l_state.fetch_state);
+				output.ReferenceColumns(l_state.all_columns, g_state.projection_ids);
+			}
+			if (output.size() == 0) {
+				if (data_p.results_execution_mode == AsyncResultsExecutionMode::TASK_EXECUTOR) {
+					// We can avoid looping, and just return as appropriate
+					data_p.async_result = AsyncResultType::HAVE_MORE_OUTPUT;
+					return;
+				}
+				// The whole batch got filtered out (e.g. deleted rows), loop back and grab more work
+				continue;
+			}
+			return;
+		}
+		case ExecutionPhase::LOCAL_STORAGE: {
+			// Scan the transaction-local storage, sequentially, always on the same thread.
+			// This won't be indexed, but at least we get the correct results.
+			auto &local_storage = LocalStorage::Get(transaction);
+			if (!g_state.CanRemoveFilterColumns()) {
+				local_storage.Scan(l_state.local_storage_state.local_state, l_state.column_ids, output);
+			} else {
+				// We need to scan into our scan chunk, and then project out the result
+				l_state.all_columns.Reset();
+				local_storage.Scan(l_state.local_storage_state.local_state, l_state.column_ids, l_state.all_columns);
+				output.ReferenceColumns(l_state.all_columns, g_state.projection_ids);
+			}
+			return;
+		}
+		}
 	}
-
-	// Fetch the data from the main storage given the row ids
-	if (state.projection_ids.empty()) {
-		bind_data.table.GetStorage().Fetch(transaction, output, state.column_ids, state.row_ids, row_count,
-		                                   state.fetch_state);
-		return;
-	}
-
-	// Otherwise, we need to first fetch into our scan chunk, and then project out the result
-	state.all_columns.Reset();
-	bind_data.table.GetStorage().Fetch(transaction, state.all_columns, state.column_ids, state.row_ids, row_count,
-	                                   state.fetch_state);
-	output.ReferenceColumns(state.all_columns, state.projection_ids);
 }
 
 //-------------------------------------------------------------------------
@@ -263,7 +350,7 @@ static unique_ptr<FunctionData> RTreeScanDeserialize(Deserializer &deserializer,
 //-------------------------------------------------------------------------
 TableFunction RTreeIndexScanFunction::GetFunction() {
 	TableFunction func("rtree_index_scan", {}, RTreeIndexScanExecute);
-	func.init_local = nullptr;
+	func.init_local = RTreeIndexScanInitLocal;
 	func.init_global = RTreeIndexScanInitGlobal;
 	func.statistics = RTreeIndexScanStatistics;
 	func.dependency = RTreeIndexScanDependency;

--- a/test/sql/index/rtree_crs.test
+++ b/test/sql/index/rtree_crs.test
@@ -1,0 +1,65 @@
+# Test that RTREE indexes can be created over GEOMETRY columns with a CRS
+require spatial
+
+load __TEST_DIR__/rtree_crs_test.db
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+CREATE TABLE t1 (geom GEOMETRY('OGC:CRS84'));
+
+statement ok
+INSERT INTO t1 SELECT ST_Point(x, y)::GEOMETRY('OGC:CRS84') FROM range(0, 10) r1(x), range(0, 10) r2(y);
+
+statement ok
+CREATE INDEX my_idx ON t1 USING RTREE (geom);
+
+# Check that we get the index scan plan
+query II
+EXPLAIN SELECT * FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(1.5, 1.5, 3.5, 3.5));
+----
+physical_plan	<REGEX>:.*RTREE_INDEX_SCAN.*
+
+# Check that the index scan returns the correct results
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(1.5, 1.5, 3.5, 3.5));
+----
+4
+
+# Deletes should still be reflected in the index
+statement ok
+DELETE FROM t1 WHERE ST_X(geom) BETWEEN 1.5 AND 3.5 AND ST_Y(geom) BETWEEN 1.5 AND 3.5;
+
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(0.5, 0.5, 4.5, 4.5));
+----
+12
+
+# The index should survive a restart
+restart
+
+query II
+EXPLAIN SELECT * FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(0.5, 0.5, 4.5, 4.5));
+----
+physical_plan	<REGEX>:.*RTREE_INDEX_SCAN.*
+
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(0.5, 0.5, 4.5, 4.5));
+----
+12
+
+# And rows can still be added to the index after the reload
+statement ok
+INSERT INTO t1 VALUES (ST_Point(2.0, 2.0)::GEOMETRY('OGC:CRS84'));
+
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(0.5, 0.5, 4.5, 4.5));
+----
+13
+
+statement ok
+DROP INDEX my_idx;
+
+statement ok
+DROP TABLE t1;

--- a/test/sql/index/rtree_crs.test
+++ b/test/sql/index/rtree_crs.test
@@ -29,7 +29,7 @@ SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(1.5, 1.5, 3.5, 3.5
 
 # Deletes should still be reflected in the index
 statement ok
-DELETE FROM t1 WHERE ST_X(geom) BETWEEN 1.5 AND 3.5 AND ST_Y(geom) BETWEEN 1.5 AND 3.5;
+DELETE FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(1.5, 1.5, 3.5, 3.5));
 
 query I
 SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(0.5, 0.5, 4.5, 4.5));

--- a/test/sql/index/rtree_delete_verification.test
+++ b/test/sql/index/rtree_delete_verification.test
@@ -1,0 +1,39 @@
+# DELETE with an indexable spatial predicate on an RTREE-indexed table used to throw
+# "INTERNAL Error: Failed to find referenced virtual column" under enable_verification,
+# because the rtree_index_scan function did not expose the table's virtual columns
+# (like rowid) after the logical plan was serialized and deserialized.
+require spatial
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+CREATE TABLE t1 (geom GEOMETRY);
+
+statement ok
+INSERT INTO t1 SELECT ST_Point(x, y) FROM range(0, 10) r1(x), range(0, 10) r2(y);
+
+statement ok
+CREATE INDEX my_idx ON t1 USING RTREE (geom);
+
+statement ok
+DELETE FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(1.5, 1.5, 3.5, 3.5));
+
+query I
+SELECT count(*) FROM t1;
+----
+96
+
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(0.5, 0.5, 4.5, 4.5));
+----
+12
+
+# Updates hit the same code path
+statement ok
+UPDATE t1 SET geom = ST_Point(100, 100) WHERE ST_Within(geom, ST_MakeEnvelope(4.5, 4.5, 6.5, 6.5));
+
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(99, 99, 101, 101));
+----
+4

--- a/test/sql/index/rtree_parallel_scan.test
+++ b/test/sql/index/rtree_parallel_scan.test
@@ -1,0 +1,73 @@
+# Test that the RTREE index scan produces correct results when running with multiple threads
+require spatial
+
+statement ok
+PRAGMA threads=4;
+
+statement ok
+CREATE TABLE t1 AS SELECT row_number() OVER () AS id, point::GEOMETRY AS geom
+FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 1000, max_y: 1000}::BOX_2D, 50_000, 1337);
+
+# Keep an identical table without an index around to compare results against
+statement ok
+CREATE TABLE t2 AS FROM t1;
+
+statement ok
+CREATE INDEX my_idx ON t1 USING RTREE (geom);
+
+# Sanity check: the indexed table uses the index scan
+query II
+EXPLAIN SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(100, 100, 700, 700));
+----
+physical_plan	<REGEX>:.*RTREE_INDEX_SCAN.*
+
+# A large result set (many batches of row ids) must match the sequential scan of the copy
+query I
+SELECT
+	(SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(100, 100, 700, 700)))
+	=
+	(SELECT count(*) FROM t2 WHERE ST_Within(geom, ST_MakeEnvelope(100, 100, 700, 700)));
+----
+true
+
+# The actual fetched rows must match too, not just the counts
+query I
+SELECT
+	(SELECT list(id ORDER BY id) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(100, 100, 700, 700)))
+	=
+	(SELECT list(id ORDER BY id) FROM t2 WHERE ST_Within(geom, ST_MakeEnvelope(100, 100, 700, 700)));
+----
+true
+
+# Deleted rows are filtered out during the parallel fetch
+statement ok
+DELETE FROM t1 WHERE id % 3 = 0;
+
+statement ok
+DELETE FROM t2 WHERE id % 3 = 0;
+
+query I
+SELECT
+	(SELECT list(id ORDER BY id) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(100, 100, 700, 700)))
+	=
+	(SELECT list(id ORDER BY id) FROM t2 WHERE ST_Within(geom, ST_MakeEnvelope(100, 100, 700, 700)));
+----
+true
+
+# Transaction-local (not yet committed to the index) rows are still returned
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t1 SELECT 100000 + range, ST_Point(150 + range % 10, 150 + range % 10) FROM range(1000);
+
+query I
+SELECT
+	(SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(100, 100, 700, 700)))
+	=
+	1000 + (SELECT count(*) FROM t2 WHERE ST_Within(geom, ST_MakeEnvelope(100, 100, 700, 700)));
+----
+true
+
+statement ok
+ROLLBACK;


### PR DESCRIPTION
In this PR we:
- Add support for creating R-Tree indexes on geometry columns with CRS, closing #824
- Fix a de/serialization issue related to virtual columns in r-tree scans
- Make the data-fetching part of the R-Tree index scan multi-threaded (the actual index traversal is still behind a lock)

The last point improves the performance of index scans by about 50% on my synthetic benchmarks, but I would assume the real gain is bigger on wider tables and thicker columns.

**25M random points test**
```
load spatial;
.mode trash

.timer on
.print 'Create data'
CREATE TABLE t1 AS SELECT row_number() OVER () AS id, point::GEOMETRY AS geom
                   FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 1000, max_y: 1000}::BOX_2D, 25_000_000, 1337);

.print 'Create index'
CREATE INDEX my_idx ON t1 USING RTREE (geom);

.print 'Begin scan'
SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(100, 100, 700, 700));
```

**Current DuckDB v1.5.4:**
```
Create data
Run Time (s): real 1.083 user 1.030571 sys 0.052126
Create index
Run Time (s): real 3.202 user 5.849422 sys 0.269274
Begin scan
Run Time (s): real 8.305 user 8.230279 sys 0.060562
```

**This PR:**
```
Create data
Run Time (s): real 1.051 user 1.001588 sys 0.049487
Create index
Run Time (s): real 3.121 user 5.680956 sys 0.256225
Begin scan
Run Time (s): real 4.801 user 13.107156 sys 24.429724
```
