### PR TITLE
Add optional parameters to ST_MakeValid

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -2020,11 +2020,20 @@ SELECT ST_MakePolygon(ST_LineString([ST_Point(0, 0), ST_Point(1, 0), ST_Point(1,
 
 ```sql
 GEOMETRY ST_MakeValid (geom GEOMETRY)
+GEOMETRY ST_MakeValid (geom GEOMETRY, method VARCHAR)
+GEOMETRY ST_MakeValid (geom GEOMETRY, method VARCHAR, keepCollapsed BOOLEAN)
 ```
 
 #### Description
 
-Returns a valid representation of the geometry
+Returns a valid representation of the geometry.
+
+`method`: accepts `LINEWORK` or `STRUCTURE`. This parameter is case-insensitive. The default value is `LINEWORK`.
+
+- The `LINEWORK` method combines all rings into a set of noded lines and then extracts valid polygons from that linework. This method keeps all input vertices.
+- The `STRUCTURE` method first makes all rings valid then merges shells and subtracts holes from shells to generate valid result. It assumes that holes and shells are correctly categorized.
+
+`keepCollapsed`: whether or not to retain components that have collapsed into a lower dimensionality. Only works with the  `STRUCTURE` method. The default value is `true`.
 
 ----
 

--- a/src/spatial/modules/geos/geos_geometry.hpp
+++ b/src/spatial/modules/geos/geos_geometry.hpp
@@ -48,7 +48,7 @@ public:
 	GeosGeometry get_minimum_rotated_rectangle() const;
 	GeosGeometry get_reversed() const;
 	GeosGeometry get_point_on_surface() const;
-	GeosGeometry get_made_valid() const;
+	GeosGeometry get_made_valid(GEOSMakeValidMethods method, bool keepCollapsed) const;
 	GeosGeometry get_voronoi_diagram() const;
 	GeosGeometry get_built_area() const;
 	GeosGeometry get_noded() const;
@@ -327,8 +327,32 @@ inline GeosGeometry GeosGeometry::get_point_on_surface() const {
 	return GeosGeometry(handle, GEOSPointOnSurface_r(handle, geom));
 }
 
-inline GeosGeometry GeosGeometry::get_made_valid() const {
-	return GeosGeometry(handle, GEOSMakeValid_r(handle, geom));
+inline GeosGeometry GeosGeometry::get_made_valid(GEOSMakeValidMethods method, bool keepCollapsed) const {
+	auto *params_raw = GEOSMakeValidParams_create_r(handle);
+	if (!params_raw) {
+		return GeosGeometry(handle, nullptr);
+	}
+
+	struct ParamsDeleter {
+		GEOSContextHandle_t h;
+		void operator()(GEOSMakeValidParams *p) const {
+			if (p) {
+				GEOSMakeValidParams_destroy_r(h, p);
+			}
+		}
+	};
+
+	unique_ptr<GEOSMakeValidParams, ParamsDeleter> params(params_raw, ParamsDeleter {handle});
+
+	if (!GEOSMakeValidParams_setMethod_r(handle, params.get(), method)) {
+		return GeosGeometry(handle, nullptr);
+	}
+
+	if (!GEOSMakeValidParams_setKeepCollapsed_r(handle, params.get(), keepCollapsed)) {
+		return GeosGeometry(handle, nullptr);
+	}
+
+	return GeosGeometry(handle, GEOSMakeValidWithParams_r(handle, geom, params.get()));
 }
 
 inline GeosGeometry GeosGeometry::get_minimum_rotated_rectangle() const {

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -1731,9 +1731,53 @@ struct ST_MakeValid {
 
 		UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](const string_t &geom_blob) {
 			const auto geom = lstate.Deserialize(geom_blob);
-			const auto valid = geom.get_made_valid();
+			const auto valid = geom.get_made_valid(GEOS_MAKE_VALID_LINEWORK, true);
 			return lstate.Serialize(result, valid);
 		});
+	}
+
+	static GEOSMakeValidMethods TryParseMethod(const string_t &method_str) {
+		auto method_std = StringUtil::Lower(method_str.GetString());
+
+		if (method_std == "linework") {
+			return GEOS_MAKE_VALID_LINEWORK;
+		} else if (method_std == "structure") {
+			return GEOS_MAKE_VALID_STRUCTURE;
+		}
+
+		throw InvalidInputException("Unknown method: '%s', accepted inputs: linework, structure",
+		                           method_str.GetString().c_str());
+	}
+
+	static void ExecuteWithMethod(DataChunk &args, ExpressionState &state, Vector &result) {
+		auto &lstate = LocalState::ResetAndGet(state);
+
+		BinaryExecutor::Execute<string_t, string_t, string_t>(
+		    args.data[0], args.data[1], result, args.size(),
+		    [&](const string_t &blob, string_t &method_str) {
+			    const auto geom = lstate.Deserialize(blob);
+			    const auto method = TryParseMethod(method_str);
+			    const auto valid = geom.get_made_valid(method, true);
+			    return lstate.Serialize(result, valid);
+		    });
+	}
+
+	static void ExecuteWithKeepCollapsed(DataChunk &args, ExpressionState &state, Vector &result) {
+		auto &lstate = LocalState::ResetAndGet(state);
+
+		TernaryExecutor::Execute<string_t, string_t, bool, string_t>(
+		    args.data[0], args.data[1], args.data[2], result, args.size(),
+		    [&](const string_t &blob, string_t &method_str, bool keepCollapsed) {
+			    const auto geom = lstate.Deserialize(blob);
+			    const auto method = TryParseMethod(method_str);
+
+			    if (method == GEOS_MAKE_VALID_LINEWORK) {
+			      throw InvalidInputException("The 'LINEWORK' method doesn't accept keepCollapsed parameter");
+			    }
+
+			    const auto valid = geom.get_made_valid(method, keepCollapsed);
+			    return lstate.Serialize(result, valid);
+		    });
 	}
 
 	static void Register(ExtensionLoader &loader) {
@@ -1745,6 +1789,29 @@ struct ST_MakeValid {
 				variant.SetBind(GeoTypes::PropagateCRS);
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
+			});
+
+			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
+				variant.AddParameter("geom", LogicalType::GEOMETRY());
+				variant.AddParameter("method", LogicalType::VARCHAR);
+				variant.SetReturnType(LogicalType::GEOMETRY());
+
+				variant.SetBind(GeoTypes::PropagateCRS);
+				variant.SetInit(LocalState::Init);
+				variant.SetFunction(ExecuteWithMethod);
+				variant.CanThrowErrors();
+			});
+
+			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
+				variant.AddParameter("geom", LogicalType::GEOMETRY());
+				variant.AddParameter("method", LogicalType::VARCHAR);
+				variant.AddParameter("keepCollapsed", LogicalType::BOOLEAN);
+				variant.SetReturnType(LogicalType::GEOMETRY());
+
+				variant.SetBind(GeoTypes::PropagateCRS);
+				variant.SetInit(LocalState::Init);
+				variant.SetFunction(ExecuteWithKeepCollapsed);
 				variant.CanThrowErrors();
 			});
 


### PR DESCRIPTION
This PR add support to two optional parameters in `ST_MakeValid`:

`method`: accepts `LINEWORK` (the default) or `STRUCTURE`.

- The `LINEWORK` method combines all rings into a set of noded lines and then extracts valid polygons from that linework. This method keeps all input vertices.
- The `STRUCTURE` method first makes all rings valid then merges shells and subtracts holes from shells to generate valid result. It assumes that holes and shells are correctly categorized.

`keepCollapsed`: whether or not to retain components that have collapsed into a lower dimensionality. Only works with the  `STRUCTURE` method. The default value is `true`.

These parameters were added to GEOS in version 3.10.