### PR TITLE
Fix null-check in st_read_meta open

### DIFF
--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -2149,6 +2149,10 @@ void Scan(ClientContext &context, TableFunctionInput &input, DataChunk &output) 
 			// Just skip anything we cant open
 			continue;
 		}
+		if (!dataset) {
+			// Open returns null when the error handler doesnt throw
+			continue;
+		}
 
 		output.data[0].SetValue(output_idx, file.path);
 		output.data[1].SetValue(output_idx, dataset->GetDriver()->GetDescription());

--- a/test/sql/gdal/st_read_meta.test
+++ b/test/sql/gdal/st_read_meta.test
@@ -1,0 +1,26 @@
+# name: test/sql/gdal/st_read_meta.test
+# group: [gdal]
+
+require spatial
+
+query I
+SELECT driver_short_name FROM st_read_meta('__WORKING_DIRECTORY__/test/data/amsterdam_roads.fgb');
+----
+FlatGeobuf
+
+# Regression: st_read_meta must not crash when GDAL fails to open a file
+statement ok
+COPY (SELECT 'not a spatial file' AS s) TO '__TEST_DIR__/not_spatial.bin' (FORMAT CSV, HEADER FALSE);
+
+query I
+SELECT COUNT(*) FROM st_read_meta('__TEST_DIR__/not_spatial.bin');
+----
+0
+
+query I
+SELECT driver_short_name FROM st_read_meta([
+    '__TEST_DIR__/not_spatial.bin',
+    '__WORKING_DIRECTORY__/test/data/amsterdam_roads.fgb',
+]);
+----
+FlatGeobuf


### PR DESCRIPTION
After the "dont throw in gdal error handles" refactor (https://github.com/duckdb/duckdb-spatial/commit/21d9675bd1e369b2bdf1ee09bf7f57fae7d392f7), GDAL's error handler no longer throws on failure. GDALDataset::Open now signals failure by returning nullptr instead of unwinding through the surrounding try/catch.

gdal_meta::Scan still relied on the throw path and dereferenced the returned unique pointer unconditionally, so any file GDAL could not recognise (garbage bytes, wrong format, a plain text file) crashed the process with a SIGSEGV inside dataset->GetDriver().

**Fix**
Skip the row when Open returns null, mirroring the existing null-checks in ST_Read's Bind and InitGlobal paths.

**Test**
Added test/sql/gdal/st_read_meta.test. It writes a non-spatial file and calls st_read_meta on it, alone and mixed into a list overload with a real dataset. Both used to crash; now return the expected rows.

**Crash signature (for reference)**

SIGSEGV (0xb) at pc=..., si_addr: 0x0
C  [spatial.duckdb_extension]  duckdb::gdal_meta::Scan(...)+0x1a8