### PR TITLE
Fix optimizer misidentifying non-geometry && as spatial join predicate

### DIFF
--- a/src/spatial/operators/spatial_join_optimizer.cpp
+++ b/src/spatial/operators/spatial_join_optimizer.cpp
@@ -113,6 +113,12 @@ static bool IsSpatialJoinPredicate(const unique_ptr<Expression> &expr, const uno
 	if (spatial_predicate_map.count(func.function.name) == 0) {
 		return false;
 	}
+	
+	// The function's operands must be GEOMETRY 
+	if (func.children[0]->return_type.id() != LogicalTypeId::GEOMETRY ||
+	    func.children[1]->return_type.id() != LogicalTypeId::GEOMETRY) {
+		return false;
+	}
 
 	const auto left_side = JoinSide::GetJoinSide(*func.children[0], left_bindings, right_bindings);
 	const auto right_side = JoinSide::GetJoinSide(*func.children[1], left_bindings, right_bindings);

--- a/test/sql/join/spatial_join_non_geometry_list.test
+++ b/test/sql/join/spatial_join_non_geometry_list.test
@@ -1,0 +1,58 @@
+# name: test/sql/join/spatial_join_non_geometry_list.test
+# description: https://github.com/duckdb/duckdb-spatial/issues/852
+# Verify && spatial join rewrites are restricted to GEOMETRY operands to prevent crashes on plain LIST columns.
+# group: [join]
+
+require spatial
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE a AS SELECT * FROM (VALUES (1, [10, 20, 30]::ubigint[]), (2, [40, 50]::ubigint[])) t(id, cells);
+
+statement ok
+CREATE TABLE b AS SELECT * FROM (VALUES (1, [20, 25]::ubigint[]), (2, [99]::ubigint[])) t(id, cells);
+
+# Verify && on LISTs does not trigger a spatial join or crash
+query II
+SELECT a.id, b.id FROM a JOIN b ON a.cells && b.cells;
+----
+1	1
+
+# Verify connection remains valid
+query I
+SELECT 1;
+----
+1
+
+# Test with VARCHAR lists to ensure fix is type-agnostic
+statement ok
+CREATE TABLE c AS SELECT * FROM (VALUES (1, ['a', 'b']::varchar[]), (2, ['c']::varchar[])) t(id, cells);
+
+statement ok
+CREATE TABLE d AS SELECT * FROM (VALUES (1, ['b', 'z']::varchar[]), (2, ['q']::varchar[])) t(id, cells);
+
+query II
+SELECT c.id, d.id FROM c JOIN d ON c.cells && d.cells;
+----
+1	1
+
+# Verify legitimate GEOMETRY && GEOMETRY still uses the spatial join
+statement ok
+CREATE TABLE lhs AS
+SELECT ST_Point(x, y) AS geom, (y * 50) + x // 10 AS id
+FROM generate_series(0, 100, 10) r1(x), generate_series(0, 100, 10) r2(y);
+
+statement ok
+CREATE TABLE rhs AS SELECT ST_MakeEnvelope(20, 20, 50, 50) AS geom;
+
+query I
+SELECT count(*) FROM lhs, rhs WHERE ST_Intersects(lhs.geom, rhs.geom);
+----
+16
+
+query II
+EXPLAIN SELECT count(*) FROM lhs, rhs WHERE ST_Intersects(lhs.geom, rhs.geom);
+----
+physical_plan	<REGEX>:.*SPATIAL_JOIN.*Join Type: INNER.*


### PR DESCRIPTION
Fixes #852 

The spatial extension's optimizer pattern-matches && purely on the operator token and rewrites any join using it into PhysicalSpatialJoin - the GDAL module (duckdb-spatial/src/spatial/modules/gdal/gdal_module.cpp) has a check for this:

```cpp
		if (func.children[0]->return_type.id() != LogicalTypeId::GEOMETRY ||
		    func.children[1]->return_type.id() != LogicalTypeId::GEOMETRY) {
			continue;
		}
```

I applied similar logic in spatial_join_optimizer.cpp (duckdb-spatial/src/spatial/operators/spatial_join_optimizer.cpp) and I believe that this resolves the bug found in #852 

I added a regression test that covers the original repro plus a sanity check that real GEOMETRY joins still get rewritten.

If I missed anything on this just let me know, thank you!!
