### PR TITLE
Reject trailing data in SGL WKB inputs

### DIFF
--- a/src/sgl/sgl.cpp
+++ b/src/sgl/sgl.cpp
@@ -4207,8 +4207,11 @@ bool wkb_reader::try_parse(geometry &out, const char *buf_ptr, const char *end_p
 
 			if (stack_depth == 0) {
 				SGL_ASSERT(parent == nullptr);
-				// Done!
-				return true;
+				if (pos == end) {
+					return true;
+				}
+				error = wkb_reader_error::TRAILING_DATA;
+				return false;
 			}
 
 			SGL_ASSERT(parent != nullptr);
@@ -4430,7 +4433,10 @@ bool wkb_reader::try_parse_stats(extent_xy &out_extent, size_t &out_vertex_count
 
 		while (true) {
 			if (stack_depth == 0) {
-				// We reached the bottom, return!
+				if (pos != end) {
+					error = wkb_reader_error::TRAILING_DATA;
+					return false;
+				}
 				out_vertex_count = vertex_count;
 				out_extent = extent;
 				return true;
@@ -4460,6 +4466,9 @@ const char *wkb_reader::get_error_message() const {
 	}
 	case wkb_reader_error::MIXED_ZM: {
 		return "Mixed Z and M values are not allowed";
+	}
+	case wkb_reader_error::TRAILING_DATA: {
+		return "Unexpected trailing data after WKB geometry";
 	}
 	case wkb_reader_error::RECURSION_LIMIT: {
 		const auto msg_fmt = "Recursion limit '%u' reached";

--- a/src/sgl/sgl.hpp
+++ b/src/sgl/sgl.hpp
@@ -783,6 +783,7 @@ enum class wkb_reader_error {
 	RECURSION_LIMIT = 3,
 	MIXED_ZM = 4,
 	INVALID_CHILD_TYPE = 5,
+	TRAILING_DATA = 6,
 };
 
 class wkb_reader {

--- a/src/sgl/sgl_test.cpp
+++ b/src/sgl/sgl_test.cpp
@@ -816,6 +816,30 @@ void test_misc_coverage() {
 	assert(geom.get_vertex_array() != nullptr);
 }
 
+void test_wkb_parsing() {
+	sgl::arena_allocator alloc;
+	sgl::wkb_reader reader(alloc);
+
+	const char point_wkb[] = {1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+	char concatenated_wkb[sizeof(point_wkb) * 2];
+	memcpy(concatenated_wkb, point_wkb, sizeof(point_wkb));
+	memcpy(concatenated_wkb + sizeof(point_wkb), point_wkb, sizeof(point_wkb));
+
+	sgl::geometry geom;
+	assert(reader.try_parse(geom, point_wkb, sizeof(point_wkb)));
+	assert(!reader.try_parse(geom, concatenated_wkb, sizeof(concatenated_wkb)));
+	assert(reader.get_error() == sgl::wkb_reader_error::TRAILING_DATA);
+	assert(strcmp(reader.get_error_message(), "Unexpected trailing data after WKB geometry") == 0);
+	assert(reader.try_parse(geom, point_wkb, sizeof(point_wkb)));
+
+	sgl::extent_xy extent;
+	size_t vertex_count;
+	assert(reader.try_parse_stats(extent, vertex_count, point_wkb, sizeof(point_wkb)));
+	assert(!reader.try_parse_stats(extent, vertex_count, concatenated_wkb, sizeof(concatenated_wkb)));
+	assert(reader.get_error() == sgl::wkb_reader_error::TRAILING_DATA);
+	assert(reader.try_parse_stats(extent, vertex_count, point_wkb, sizeof(point_wkb)));
+}
+
 int main() {
 
 	test_allocator();
@@ -832,6 +856,7 @@ int main() {
 	test_prepared_geometry();
 
 	test_misc_coverage();
+	test_wkb_parsing();
 
 	printf("All tests passed!\n");
 	return 0;

--- a/test/sql/geometry/st_2d_fromwkb.test
+++ b/test/sql/geometry/st_2d_fromwkb.test
@@ -17,3 +17,18 @@ query I
 SELECT ST_Polygon2DFromWKB(ST_AsWKB(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')));
 ----
 POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+
+statement error
+SELECT ST_Point2DFromWKB(ST_AsWKB(ST_Point(1, 2)) || ST_AsWKB(ST_Point(9, 9)));
+----
+Invalid Input Error: Could not parse WKB input: Unexpected trailing data after WKB geometry
+
+statement error
+SELECT ST_LineString2DFromWKB(ST_AsWKB(ST_GeomFromText('LINESTRING(0 0, 1 1)')) || ST_AsWKB(ST_Point(9, 9)));
+----
+Invalid Input Error: Could not parse WKB input: Unexpected trailing data after WKB geometry
+
+statement error
+SELECT ST_Polygon2DFromWKB(ST_AsWKB(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 0))')) || ST_AsWKB(ST_Point(9, 9)));
+----
+Invalid Input Error: Could not parse WKB input: Unexpected trailing data after WKB geometry

--- a/test/sql/geometry/st_ashexwkb.test
+++ b/test/sql/geometry/st_ashexwkb.test
@@ -45,6 +45,11 @@ SELECT ST_GeomFromHEXWKB('010800000000000000');
 ----
 Invalid Input Error: Could not parse HEX WKB string: WKB type 'CIRCULARSTRING' is not supported! (type id: 8, SRID: 0)
 
+statement error
+SELECT ST_GeomFromHEXWKB(ST_AsHEXWKB(ST_Point(1, 2)) || ST_AsHEXWKB(ST_Point(9, 9)));
+----
+Invalid Input Error: Could not parse HEX WKB string: Unexpected trailing data after WKB geometry
+
 # Test rountrips properly
 statement ok
 CREATE TABLE types (geom GEOMETRY);
@@ -101,4 +106,3 @@ query I
 SELECT ST_GeomFromHEXWKB('00000000030000000100000005000000000000000000000000000000003ff000000000000000000000000000003ff00000000000003ff000000000000000000000000000003ff000000000000000000000000000000000000000000000')
 ----
 POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-


### PR DESCRIPTION
Spatial's SGL reader returned success as soon as it finished the outermost WKB
geometry, even when bytes remained in the input. The 2D constructors,
`ST_GeomFromHEXWKB`, and statistics parsing could consequently accept a valid
geometry followed by arbitrary data or a second geometry.

Require the parser position to reach the end of the supplied buffer in both
the materialising and statistics paths, and report a specific trailing-data
error otherwise. The standalone regression also verifies the error category,
message, and successful reader reuse after a rejected input.

The standalone Clang ASan/UBSan suite and the full Spatial `relassert` build
pass. Focused SQL coverage exercises all three 2D constructors and HEX WKB;
the adjacent WKB round-trip suites also pass.

Related: duckdb/duckdb#24296 and duckdb/duckdb#24301 — the corresponding
DuckDB core `ST_GeomFromWKB` path is fixed separately in duckdb/duckdb#24559.


---
Verified (2026-08-05): `test/sql/geometry/st_2d_fromwkb.test` and
`test/sql/geometry/st_ashexwkb.test` fail on unpatched duckdb-spatial main
`2b072abd2a` (trailing bytes silently accepted, e.g. a point followed by
garbage still returns `POINT_2D {'x': 1.0, 'y': 2.0}`) and pass with this
branch (6 and 27 assertions).
