### PR TITLE
fix: update winding number vertex handling in ST_Contains

### DIFF
--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -2084,7 +2084,7 @@ struct ST_Contains {
 						// return Contains::ON_EDGE;
 						contains = false;
 						break;
-					} else if (side == Side::LEFT && (y1 < y && y <= y2)) {
+					} else if (side == Side::LEFT && (y1 <= y && y < y2)) {
 						winding_number++;
 					} else if (side == Side::RIGHT && (y2 <= y && y < y1)) {
 						winding_number--;

--- a/test/sql/geometry/st_contains.test
+++ b/test/sql/geometry/st_contains.test
@@ -1,0 +1,85 @@
+# name: test/sql/geometry/st_contains.test
+# group: [geometry]
+#
+# https://github.com/duckdb/duckdb-spatial/issues/806
+
+require spatial
+
+# Query from example in issue 806
+
+query IIII
+WITH poly AS (
+  SELECT ST_GeomFromText(
+    'POLYGON ((11.6742158 48.156714, 11.6781624 48.144285, 11.6837275 48.1447925, 11.6742158 48.156714))'
+  ) AS geom
+),
+pts AS (
+  SELECT * FROM (VALUES
+    (-123.1061120::DOUBLE, 48.144285::DOUBLE)
+  ) AS t(lon, lat)
+)
+SELECT
+  ST_XMin(geom) AS xmin,
+  ST_XMax(geom) AS xmax,
+  ST_Contains(geom::POLYGON_2D, ST_MakePoint(lon, lat)::POINT_2D) AS typed_contains,
+  ST_Contains(geom, ST_MakePoint(lon, lat)::GEOMETRY) AS generic_contains
+FROM poly, pts;
+----
+11.6742158	11.6837275	false	false
+
+# Check inside
+
+query I
+SELECT ST_Contains(
+    ST_GeomFromText('POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))')::POLYGON_2D,
+    ST_MakePoint(2, 2)::POINT_2D
+);
+----
+true
+
+# Check outside
+
+query I
+SELECT ST_Contains(
+    ST_GeomFromText('POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))')::POLYGON_2D,
+    ST_MakePoint(10, 10)::POINT_2D
+);
+----
+false
+
+# Boundary exclusion edge
+
+query I
+SELECT ST_Contains(
+    ST_GeomFromText('POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))')::POLYGON_2D,
+    ST_MakePoint(2, 0)::POINT_2D  -- on an edge
+);
+----
+false
+
+# Boundary exclusion vertex
+
+query I
+SELECT ST_Contains(
+    ST_GeomFromText('POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))')::POLYGON_2D,
+    ST_MakePoint(0, 0)::POINT_2D  -- on a vertex
+);
+----
+false
+
+# NULL handling
+
+query I
+SELECT ST_Contains(NULL::POLYGON_2D, ST_MakePoint(0, 0)::POINT_2D);
+----
+NULL
+
+# NULL handling
+
+query I
+SELECT ST_Contains(
+    ST_GeomFromText('POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))')::POLYGON_2D,
+    NULL::POINT_2D
+);
+----
+NULL


### PR DESCRIPTION
Fixes #806

I believe all that needs to be changed on this is in the inequality checks below:

Original:

```cpp
} else if (side == Side::LEFT && (y1 < y && y <= y2)) {
  winding_number++;
} else if (side == Side::RIGHT && (y2 <= y && y < y1)) {
  winding_number--;
}
```

This can be found in lines 2087-2091 (src/spatial/modules/main/spatial_functions_scalar.cpp) - the change is just in the consistency on the winding number loops endpoint handling:

Updated:

```cpp
} else if (side == Side::LEFT && (y1 <= y && y < y2)) {
  winding_number++;
} else if (side == Side::RIGHT && (y2 <= y && y < y1)) {
  winding_number--;
}
```

Set (y1 <= y && y < y2) instead of (y1 < y && y <= y2)

I dug around on how GEOS handled ray crossing and found their `RayCrossingCounter::countSegment` with the below comments and inequality checks:

```cpp
// To avoid double-counting shared vertices, we use the convention that
// - an upward edge includes its starting endpoint, and excludes its
//   final endpoint
// - a downward edge excludes its starting endpoint, and includes its
//   final endpoint

if((p1.y > point.y && p2.y <= point.y) || (p2.y > point.y && p1.y <= point.y)) {
    // orientation determines whether this is counted as a crossing
}
```

With changing the inequality this will now enforce the same rule - a shared vertex on the scanline is claimed by exactly one of its two adjacent edges.

I've added the statement from #806 in a test suite and this seems to resolve the problem, I also added a couple of other tests to make sure it still worked for other scenarios as well.

Let me know if I am off in my thinking on this, and thanks in advance for the review!
