### PR TITLE
fix: handle non-flat row id vectors when replaying RTREE index appends and deletes from the WAL

### DIFF
--- a/src/spatial/index/rtree/rtree_index.cpp
+++ b/src/spatial/index/rtree/rtree_index.cpp
@@ -225,7 +225,6 @@ void RTreeIndex::CommitDrop(IndexLock &index_lock) {
 template <class CALLBACK = std::function<void(const RTreeEntry &)>>
 static void ConvertToEntries(Vector &box_vec, Vector &rowid_vec, idx_t count, CALLBACK &&callback) {
 	const auto &box_validity = FlatVector::Validity(box_vec);
-	const auto &row_validity = FlatVector::Validity(rowid_vec);
 
 	const auto &box_entries = StructVector::GetEntries(box_vec);
 	const auto box_xmin_data = FlatVector::GetData<float>(*box_entries[0]);
@@ -233,10 +232,13 @@ static void ConvertToEntries(Vector &box_vec, Vector &rowid_vec, idx_t count, CA
 	const auto box_xmax_data = FlatVector::GetData<float>(*box_entries[2]);
 	const auto box_ymax_data = FlatVector::GetData<float>(*box_entries[3]);
 
-	const auto row_data = FlatVector::GetData<row_t>(rowid_vec);
+	UnifiedVectorFormat rowid_format;
+	rowid_vec.ToUnifiedFormat(count, rowid_format);
+	const auto row_data = UnifiedVectorFormat::GetData<row_t>(rowid_format);
 
 	for (idx_t i = 0; i < count; i++) {
-		if (!box_validity.RowIsValid(i) || !row_validity.RowIsValid(i)) {
+		const auto row_idx = rowid_format.sel->get_index(i);
+		if (!box_validity.RowIsValid(i) || !rowid_format.validity.RowIsValid(row_idx)) {
 			continue;
 		}
 
@@ -246,7 +248,7 @@ static void ConvertToEntries(Vector &box_vec, Vector &rowid_vec, idx_t count, CA
 		box.max.x = box_xmax_data[i];
 		box.max.y = box_ymax_data[i];
 
-		const auto row = row_data[i];
+		const auto row = row_data[row_idx];
 
 		RTreeEntry new_entry = {RTree::MakeRowId(row), box};
 
@@ -256,14 +258,16 @@ static void ConvertToEntries(Vector &box_vec, Vector &rowid_vec, idx_t count, CA
 }
 
 ErrorData RTreeIndex::Insert(IndexLock &lock, DataChunk &input, Vector &row_vec) {
+	const auto count = input.size();
 
 	key_chunk.Reset();
 	key_executor->ExecuteExpression(input, key_chunk.data[0]);
+	key_chunk.SetCardinality(count);
 	key_chunk.Flatten();
 
 	auto &box_vec = key_chunk.data[0];
 
-	ConvertToEntries(box_vec, row_vec, input.size(), [&](const RTreeEntry &entry) { tree->Insert(entry); });
+	ConvertToEntries(box_vec, row_vec, count, [&](const RTreeEntry &entry) { tree->Insert(entry); });
 
 	return ErrorData {};
 }
@@ -284,6 +288,7 @@ void RTreeIndex::Delete(IndexLock &lock, DataChunk &input, Vector &row_vec) {
 
 	key_chunk.Reset();
 	key_executor->ExecuteExpression(expr_chunk, key_chunk.data[0]);
+	key_chunk.SetCardinality(count);
 	key_chunk.Flatten();
 
 	auto &box_vec = key_chunk.data[0];

--- a/test/sql/index/rtree_persistence_wal_append.test
+++ b/test/sql/index/rtree_persistence_wal_append.test
@@ -1,0 +1,106 @@
+# name: test/sql/index/rtree_persistence_wal_append.test
+# group: [index]
+
+# Appends and deletes on an existing RTREE index are buffered during WAL replay (when spatial isn't
+# loaded) and applied when the index is bound. Row ids arrive as a dictionary vector, which used to
+# error with "Operation requires a flat vector", making the database uncheckpointable.
+# See https://github.com/duckdb/duckdb-spatial/issues/861
+#
+# The runner checkpoints whenever the WAL is non-empty, so 'checkpoint_threshold' must be raised
+# after each restart to keep the WAL alive.
+
+require spatial
+
+load __TEST_DIR__/rtree_persistence_wal_append.db
+
+statement ok
+SET checkpoint_threshold='1GB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+CREATE TABLE t1 (geom GEOMETRY);
+
+statement ok
+CREATE INDEX my_idx ON t1 USING RTREE (geom);
+
+# Insert after index creation so the appends go through the WAL
+statement ok
+INSERT INTO t1 SELECT ST_Point(x, y) FROM range(0, 100) r1(x), range(0, 100) r2(y);
+
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(9.5, 9.5, 20.5, 20.5));
+----
+121
+
+restart
+
+statement ok
+SET checkpoint_threshold='1GB';
+
+# Binding the index applies the buffered appends
+query II
+EXPLAIN SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(9.5, 9.5, 20.5, 20.5));
+----
+physical_plan	<REGEX>:.*RTREE_INDEX_SCAN.*
+
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(9.5, 9.5, 20.5, 20.5));
+----
+121
+
+statement ok
+INSERT INTO t1 VALUES (ST_Point(1000, 1000));
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT count(*) FROM t1;
+----
+10001
+
+# Every row is in the index, not just in the table
+query I
+SELECT count(*) FROM rtree_index_dump('my_idx') WHERE row_id IS NOT NULL;
+----
+10001
+
+# The same applies to deletes replayed from the WAL
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+DELETE FROM t1 WHERE rowid < 1000;
+
+restart
+
+statement ok
+SET checkpoint_threshold='1GB';
+
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(9.5, 9.5, 20.5, 20.5));
+----
+121
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT count(*) FROM t1;
+----
+9001
+
+# The deleted rows are gone from the table
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(-0.5, -0.5, 9.5, 9.5));
+----
+0
+
+# ...and from the index itself. The query above would pass regardless, since deleted rows are
+# filtered out on fetch, so check the index directly for dangling entries.
+query I
+SELECT count(*) FROM rtree_index_dump('my_idx') WHERE row_id IS NOT NULL;
+----
+9001


### PR DESCRIPTION
Fixes #861.

### Problem

If a database file is closed without checkpointing while its WAL contains inserts into a table with an `RTREE` index, then on the next open:

- any statement that binds the index fails with `INTERNAL Error: Operation requires a flat vector but a non-flat vector was encountered`
- `CHECKPOINT` fails with the same error, after which DuckDB reports the database as invalidated

It doesn't appear to clear itself. Every subsequent open replays the same WAL and hits the same failure. The data itself seems intact — `SELECT count(*)` returns every row and a read-only open reads everything — but the file can't checkpoint again until someone drops the index by hand.

A single inserted row is enough to reproduce:

```sql
-- Session 1
PRAGMA disable_checkpoint_on_shutdown;
LOAD spatial;
CREATE TABLE t (geom GEOMETRY);
CREATE INDEX i ON t USING RTREE (geom);
INSERT INTO t VALUES (ST_Point(0,0));
```

```sql
-- Session 2, same file
LOAD spatial;
CHECKPOINT;
-- FATAL Error: Failed to create checkpoint because of error:
--   Operation requires a flat vector but a non-flat vector was encountered
```

### Root cause

When the WAL is replayed without the spatial extension loaded, the `RTREE` index cannot be bound, so DuckDB buffers the appends and deletes and applies them later after something binds the index. `BoundIndex::ApplyBufferedReplays` slices the buffered chunk to build the row id vector:

```cpp
SelectionVector sel(offset_in_chunk, rows_to_process);
...
Vector row_ids(state.current_chunk.data.back(), sel, rows_to_process);
const auto error = Append(table_chunk, row_ids, append_info);
```

That produces a dictionary vector. `ConvertToEntries` read it with `FlatVector::Validity` and `FlatVector::GetData`, which throw on anything non-flat.

ART indexes may survive the same replay path because `ART::GenerateKeyVectors` goes through `UnifiedVectorFormat`, which is why the failure should be specific to `RTREE`.

### Fix

- `ConvertToEntries` reads the row ids through `UnifiedVectorFormat`, indexing both the data and the validity mask through the selection vector. This covers `Insert` and `Delete`, which share the helper.
- `key_chunk.SetCardinality(count)` before `key_chunk.Flatten()` in `Insert` and `Delete`. `DataChunk::Flatten()` flattens up to `size()`, which is 0 right after `Reset()`, so the flatten didn't do anything. I don't see a known trigger, since the key vector comes back flat on both paths, but the call was not doing what it reads like it should be doing.

### Test

`test/sql/index/rtree_persistence_wal_append.test` covers both the append and the delete replay: create the index, write, restart, then index scan and `CHECKPOINT`. It fails before this change and passes after.

Two notes on the test:

- The existing `rtree_persistence_wal.test` didn't look like it was actually exercising WAL replay. The sqllogictest runner defaults `checkpoint_wal_size` to 0 (`TestConfiguration::GetCheckpointWALSize`), so it checkpoints as soon as the WAL is non-empty and no `.wal` file survives the `restart`. The new test raises `checkpoint_threshold` after every restart, which is what keeps the WAL alive into the next session. I left the existing test alone, but certainly they can be merged.
- The delete assertions read the index directly with `rtree_index_dump` instead of only counting table rows. Deleted rows are filtered out when the index scan fetches them from the table, so a table-level count passes whether or not the entries were actually removed from the index.

### Related

- duckdb/duckdb-rs#733 looks to be the same error and same stack, reported against v1.5.1 on linux_amd64. Filed on the Rust binding repo; the reproduction there goes through Rust and deliberately leaks a connection, which made it look like a connection-lifetime problem rather than an uncheckpointed WAL.
- #706 appears to be unrelated despite also involving `RTreeIndex::Append`. Its stack crashes inside `RTree::SplitNode` / `SortEntriesByRowId` on the ordinary `LocalTableStorage::AppendToIndexes` path, which points at concurrent tree mutation rather than vector layout.
