### PR TITLE
fix(rtree): flatten rowid vector in ConvertToEntries to fix WAL replay appends (#861)

### DIFF
--- a/src/spatial/index/rtree/rtree_index.cpp
+++ b/src/spatial/index/rtree/rtree_index.cpp
@@ -224,6 +224,9 @@ void RTreeIndex::CommitDrop(IndexLock &index_lock) {
 
 template <class CALLBACK = std::function<void(const RTreeEntry &)>>
 static void ConvertToEntries(Vector &box_vec, Vector &rowid_vec, idx_t count, CALLBACK &&callback) {
+	// rowid_vec may be non-flat (e.g. sequence vector during WAL replay buffered index appends)
+	rowid_vec.Flatten(count);
+
 	const auto &box_validity = FlatVector::Validity(box_vec);
 	const auto &row_validity = FlatVector::Validity(rowid_vec);
 

--- a/test/sql/index/rtree_persistence_wal.test
+++ b/test/sql/index/rtree_persistence_wal.test
@@ -38,3 +38,27 @@ query I
 SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(450, 450, 650, 650));
 ----
 43
+
+# Insert additional rows into existing index while checkpointing is disabled (lands in WAL)
+statement ok
+INSERT INTO t1 VALUES (ST_Point(500, 500)), (ST_Point(600, 600));
+
+restart
+
+# Replay WAL into existing index and checkpoint (regression test for #861: non-flat row identifiers)
+statement ok
+CHECKPOINT;
+
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(450, 450, 650, 650));
+----
+45
+
+# Additional insert and index scan verification after WAL replay
+statement ok
+INSERT INTO t1 VALUES (ST_Point(550, 550));
+
+query I
+SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(450, 450, 650, 650));
+----
+46


### PR DESCRIPTION
### Summary

Fixes #861

When a persistent DuckDB database containing an existing `RTREE` index has rows appended without an immediate checkpoint, the uncheckpointed inserts are stored in the write-ahead log (WAL).

On subsequent database opens, DuckDB replays the WAL into the index via `BoundIndex::Append(DataChunk &appended_data, Vector &row_identifiers)`. During buffered replays, `row_identifiers` can be passed as a non-flat vector (such as a `VectorType::SEQUENCE_VECTOR` or dictionary/slice).

`RTreeIndex::Insert` and `RTreeIndex::Delete` delegate to `ConvertToEntries`, which previously accessed `rowid_vec` directly through:
```cpp
const auto &row_validity = FlatVector::Validity(rowid_vec);
...
const auto row_data = FlatVector::GetData<row_t>(rowid_vec);
```
Because `FlatVector::GetData` and `FlatVector::Validity` enforce `FlatVector::VerifyFlatVector`, encountering a non-flat vector triggered:
```
INTERNAL Error: Operation requires a flat vector but a non-flat vector was encountered
```
During a `CHECKPOINT`, this error escalated to `FATAL Error: Failed to create checkpoint...`, leaving the database marked as invalidated.

### Changes

1. **`src/spatial/index/rtree/rtree_index.cpp`**:
   - Added `rowid_vec.Flatten(count);` at the start of `ConvertToEntries`.
   - If `rowid_vec` is already flat, this is a fast no-op; if it is a `SequenceVector` or other non-flat vector type from WAL replay or batch processing, it flattens the vector in-place so `FlatVector::GetData<row_t>` and `FlatVector::Validity` succeed safely.
2. **`test/sql/index/rtree_persistence_wal.test`**:
   - Extended the WAL persistence test suite to insert rows into an existing RTREE index while checkpointing is disabled (`PRAGMA disable_checkpoint_on_shutdown`), restart the connection, replay the WAL, trigger `CHECKPOINT`, and verify subsequent inserts and index scans.

### Verification

- Validated reproduction locally: reproduced `INTERNAL Error` on uncheckpointed index WAL replay prior to the fix.
- Validated fix locally and on CI (both `linux_arm64` and `linux_amd64` distribution pipelines passed).
