### PR TITLE
Update vcpkg to 2026.06.24

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -30,7 +30,8 @@ jobs:
       duckdb_version: main
       ci_tools_version: main
       extension_name: spatial
-      vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+      # Temporary override; remove when extension-ci-tools updates its default.
+      vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
       exclude_archs: 'linux_amd64_musl'
 
   duckdb-latest-deploy:
@@ -86,4 +87,4 @@ jobs:
           build-type: relassert
           build: python3 duckdb/scripts/ci/retry.py -- make relassert
           test: make unittest_relassert
-          vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+          vcpkg-commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -44,5 +44,5 @@
       }
     ]
   },
-  "builtin-baseline" : "84bab45d415d22042bd0b9081aea57f362da3f35"
+  "builtin-baseline" : "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3"
 }


### PR DESCRIPTION
This pr updates the vcpkg version to 2026.06.24.

This is part of updating all of duckdb, therefore merging should be done in coordination with stakeholders.

References:
https://github.com/duckdb/duckdb/pull/25094
https://github.com/duckdblabs/duckdb-internal/issues/10429